### PR TITLE
Fix hero name text color fringing by reducing chromatic aberration

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -2373,7 +2373,7 @@ class HeroNameShader {
         disp     -= (toM / (md * md + 0.06)) * 0.007;
 
         /* chromatic aberration — 3 wavelengths offset horizontally */
-        float ab = 0.010;
+        float ab = 0.003;
         float aR = texture2D(uTex, clamp(uv + disp + vec2( ab, 0.0), 0.0, 1.0)).a;
         float aG = texture2D(uTex, clamp(uv + disp,                  0.0, 1.0)).a;
         float aB = texture2D(uTex, clamp(uv + disp - vec2( ab, 0.0), 0.0, 1.0)).a;


### PR DESCRIPTION
The chromatic aberration offset in the HeroNameShader was set to 0.010
(1% of canvas width), causing heavy RGB channel separation that made
the "Stefano Masneri" text appear with ugly cyan/green/dark outlines
against the blue background. Reduced to 0.003 for a subtle iridescent
shimmer without the visible color splitting.

https://claude.ai/code/session_017temFWWQt8TeUJBP5pYaYF