### PR TITLE
Replace SM nav logo with home icon; add PhD defense slides link

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -129,6 +129,17 @@ a {
   text-decoration: none;
 }
 
+.inline-link {
+  color: var(--accent2);
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+  transition: opacity var(--t-fast);
+}
+
+.inline-link:hover {
+  opacity: 0.75;
+}
+
 a:focus-visible,
 button:focus-visible {
   outline: 2px solid var(--accent2);
@@ -220,19 +231,18 @@ h3 {
 }
 
 .nav-logo {
-  font-family: var(--font-serif);
-  font-size: 1.15rem;
-  font-weight: 700;
-  background: linear-gradient(135deg, var(--accent), var(--accent2));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  letter-spacing: 0.04em;
+  display: flex;
+  align-items: center;
   transition: opacity var(--t-fast);
 }
 
 .nav-logo:hover {
-  opacity: 0.8;
+  opacity: 0.75;
+}
+
+.nav-home-icon {
+  width: 1.5rem;
+  height: 1.5rem;
 }
 
 .nav-links {

--- a/cv.html
+++ b/cv.html
@@ -42,7 +42,18 @@
   <!-- ═══════════════ NAVIGATION ═══════════════ -->
   <nav id="navbar" role="navigation" aria-label="Main navigation">
     <div class="nav-inner">
-      <a href="index.html" class="nav-logo" aria-label="Home">SM</a>
+      <a href="index.html" class="nav-logo" aria-label="Home">
+        <svg class="nav-home-icon" viewBox="0 0 24 24" fill="none" stroke="url(#nav-grad)" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <defs>
+            <linearGradient id="nav-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stop-color="#6c63ff"/>
+              <stop offset="100%" stop-color="#00d4ff"/>
+            </linearGradient>
+          </defs>
+          <path d="M3 9.5L12 3l9 6.5V21a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V9.5z"/>
+          <path d="M9 22V12h6v10"/>
+        </svg>
+      </a>
       <button class="nav-toggle" id="nav-toggle" aria-expanded="false" aria-label="Toggle menu">
         <span></span><span></span><span></span>
       </button>

--- a/index.html
+++ b/index.html
@@ -103,7 +103,18 @@
   <!-- ═══════════════ NAVIGATION ═══════════════ -->
   <nav id="navbar" role="navigation" aria-label="Main navigation">
     <div class="nav-inner">
-      <a href="#hero" class="nav-logo" aria-label="Home">SM</a>
+      <a href="#hero" class="nav-logo" aria-label="Home">
+        <svg class="nav-home-icon" viewBox="0 0 24 24" fill="none" stroke="url(#nav-grad)" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <defs>
+            <linearGradient id="nav-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stop-color="#6c63ff"/>
+              <stop offset="100%" stop-color="#00d4ff"/>
+            </linearGradient>
+          </defs>
+          <path d="M3 9.5L12 3l9 6.5V21a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V9.5z"/>
+          <path d="M9 22V12h6v10"/>
+        </svg>
+      </a>
       <button class="nav-toggle" id="nav-toggle" aria-expanded="false" aria-label="Toggle menu">
         <span></span><span></span><span></span>
       </button>
@@ -213,7 +224,8 @@
                 My work spans <strong>generative AI</strong>, <strong>deep learning</strong>,
                 <strong>3D reconstruction</strong>, and <strong>large language models</strong>. I hold a
                 <strong>PhD from the University of the Basque Country</strong>, where I
-                researched collaborative, multi-user augmented reality experiences for education.
+                researched collaborative, multi-user augmented reality experiences for education
+                (<a href="#" class="inline-link">defense slides</a>).
               </p>
               <p>
                 I have worked in Italy, Germany, and Spain at both research institutions and software companies — from


### PR DESCRIPTION
- Swap the "SM" text logo in both index.html and cv.html with a
  minimal inline SVG house icon using the existing purple→cyan gradient
- Update .nav-logo CSS to flex-center the SVG; add .nav-home-icon sizing
- Add .inline-link utility style (cyan, underlined) for in-text links
- Insert "(defense slides)" placeholder link after the PhD sentence
  in the about section of index.html

https://claude.ai/code/session_01KvsD63yDoJbFuQaHsSukL1