### PR TITLE
Rework Writing section and plan Projects/Portfolio feature

### DIFF
--- a/docs/plan-projects.md
+++ b/docs/plan-projects.md
@@ -1,0 +1,170 @@
+# Plan: Projects / Portfolio Section
+
+## Problem
+
+The current "What I Work On" (Research) section contains six flip-cards covering broad topic
+areas (Computer Vision, AR, etc.). These are intentionally general — they describe *domains*,
+not specific deliverables. There is nowhere on the site where a visitor can see a concrete
+artefact of what has actually been built: a screenshot of an AR classroom, a model output, a
+demo video, a GitHub repo.
+
+A separate **Projects** section solves this without cluttering the Research cards.
+
+---
+
+## Proposed Structure
+
+### 1. Homepage strip — "Projects" section
+
+- Positioned between Publications and Writing (or between Research and Skills — TBD).
+- A horizontally-scrollable row of compact project cards (similar cadence to the Research
+  carousel but visually heavier, led by an image).
+- Each card contains:
+  - **Thumbnail image** (16:9 ratio, `img/projects/<slug>-thumb.jpg`)
+  - **Title** (one short line)
+  - **Year**
+  - **Tag badges** (1–3 keywords, e.g. "AR", "Computer Vision", "LLM")
+  - **Short description** (2–3 sentences max)
+  - **"View project →"** link — jumps to the matching anchor in `projects.html`
+- A "View all projects →" button after the row, linking to `projects.html`.
+- The homepage shows a capped number (e.g. 4) of the most recent projects; the rest live only
+  on `projects.html`.
+
+### 2. `projects.html` — dedicated project detail page
+
+- Same shell as `blog.html` / `cv.html` (shared nav, footer, styles).
+- Each project is a self-contained section (`<section id="<slug}">`) so homepage cards can
+  deep-link to it with `projects.html#ar-education`.
+- Full-width layout per project:
+  - Hero image **or** embedded video (YouTube/Vimeo `<iframe>`, lazy-loaded)
+  - Title, year, tags
+  - Full description (HTML, can include multiple paragraphs, lists, sub-images)
+  - Link row: paper / GitHub / demo / video (only those that exist)
+- Projects listed newest-first.
+
+### 3. Data file — `data/projects.js`
+
+```js
+const PROJECTS = [
+  {
+    id:          'clear-ar-education',          // used as HTML anchor in projects.html
+    title:       'CleAR: Multi-user AR for Education',
+    year:        '2023',
+    tags:        ['AR', 'Education', 'Unity'],
+    thumb:       'img/projects/clear-thumb.jpg',
+    description: 'Short 2–3 sentence summary shown on the homepage card.',
+    url:         'projects.html#clear-ar-education',
+  },
+  // ...
+];
+```
+
+`projects.html` content (the rich per-project HTML) is authored directly in the HTML file
+rather than generated from data, because it is inherently freeform (mixed media, arbitrary
+layout per project). The data file drives only the homepage cards.
+
+### 4. Script — `scripts/new-project.js`
+
+Automates the boilerplate of adding a new project:
+
+- **Input**: a Markdown file with YAML frontmatter (see template below).
+- **Output 1**: appends a new `<section id="<slug>">` block to `projects.html` inside a
+  designated injection comment zone.
+- **Output 2**: prepends a new entry to the `PROJECTS` array in `data/projects.js`.
+- Flags: `--dry-run`, `--help` (consistent with other scripts).
+
+#### Frontmatter fields
+
+```yaml
+---
+id:          clear-ar-education        # kebab-case, becomes HTML anchor
+title:       "CleAR: Multi-user AR for Education"
+year:        "2023"
+tags:        "AR, Education, Unity"    # comma-separated
+thumb:       "img/projects/clear-thumb.jpg"
+description: "Short 2–3 sentence summary for the homepage card."
+# Optional links (omit any that don't apply):
+link_paper:  "https://link.springer.com/..."
+link_github: "https://github.com/..."
+link_demo:   "https://..."
+link_video:  "https://youtube.com/..."
+---
+
+Full project description in Markdown.
+Can span multiple paragraphs, include images, lists, etc.
+```
+
+#### Template file
+
+`docs/project-template.md` — a copy of the above frontmatter with inline comments explaining
+each field, to be duplicated when starting a new project entry.
+
+### 5. CSS additions (`css/styles.css`)
+
+- `.project-card` — homepage card with thumbnail, matches general site aesthetic.
+- `.project-card__thumb` — 16:9 image, `object-fit: cover`.
+- `.project-detail` — per-project section on `projects.html`: full-width, comfortable reading
+  width, generous spacing between projects.
+- `.project-detail__media` — wraps `<img>` or `<iframe>` embed; `aspect-ratio: 16/9`.
+- `.project-links` — horizontal row of pill-shaped links (paper, GitHub, demo…).
+- All new components respect `prefers-reduced-motion` and are responsive.
+
+### 6. JS additions (`js/main.js`)
+
+Two new render functions (following the existing pattern):
+
+```js
+// Renders homepage project cards from PROJECTS (data/projects.js)
+function renderProjects() { ... }
+
+// No render needed for projects.html detail sections — they are static HTML.
+// Only setFooterYear() and nav/scroll behaviours apply.
+```
+
+`renderProjects()` is called from the `DOMContentLoaded` handler, guarded by element existence
+check (same pattern as `renderBlog`).
+
+### 7. `package.json` additions
+
+```json
+"new-project": "node scripts/new-project.js"
+```
+
+### 8. Tests
+
+- `test/new-project.test.js` — unit tests for frontmatter parsing, HTML generation, and
+  `data/projects.js` update logic (mirrors `test/new-post.test.js` structure).
+- `test/main.test.js` — add `renderProjects` to the exported-function tests.
+
+---
+
+## Implementation Order
+
+1. Add `img/projects/` directory (placeholder `README` or first real thumbnail).
+2. Create `data/projects.js` with the shape comment and an empty `PROJECTS = []` array.
+3. Create `projects.html` skeleton (nav, footer, injection zone comment, script tags).
+4. Add CSS for `.project-card` and `.project-detail` to `css/styles.css`.
+5. Add `renderProjects()` to `js/main.js`; run `npm run minify`.
+6. Add "Projects" section to `index.html`.
+7. Write `scripts/new-project.js` with frontmatter parser, HTML generator, and data updater.
+8. Write `docs/project-template.md`.
+9. Add `npm run new-project` to `package.json`.
+10. Write `test/new-project.test.js`; run `npm test` and confirm all 206+ tests pass.
+11. Add 2–3 real project entries to validate the pipeline end-to-end.
+
+---
+
+## Open Questions / Decisions Needed
+
+- **Section placement**: between Publications and Writing, or between Research and Skills?
+  (Between Publications and Writing feels natural — it's the "show, don't tell" counterpart to
+  the publication list above it.)
+- **Homepage card count cap**: 4 seems right (one row on wide screens), but could be 3 or 6.
+- **Video embeds**: iframes add third-party requests. Prefer a "click to load" pattern (poster
+  image + play button that swaps in the iframe on click) to keep the page privacy-first.
+- **Thumbnail production**: what source material exists? Screenshots from papers, demo
+  recordings, conference slides? Decide before starting implementation so the right image sizes
+  can be established.
+- **`projects.html` detail content**: hand-authored HTML gives full flexibility but is not
+  scriptable. If projects become numerous, consider a richer data schema in `data/projects.js`
+  that drives the full detail view too (more work upfront, easier to maintain long-term).

--- a/index.html
+++ b/index.html
@@ -573,30 +573,22 @@
     </div>
   </section>
 
-  <!-- ═══════════════ BLOG ═══════════════ -->
-  <!--
-    HOW TO ADD A BLOG POST
-    ────────────────────────
-    Open data/blog.js and add an entry to BLOG_POSTS:
-    {
-      title:   "My first post",
-      date:    "2024-12-01",
-      excerpt: "A short summary...",
-      tag:     "Engineering",
-      readMin: 5,
-      url:     "blog/my-first-post.html"   // or a full URL
-    }
-    Cards appear automatically — newest first.
-    Leave BLOG_POSTS = [] to show a "Coming soon" placeholder.
-  -->
-  <section id="blog" class="section" aria-label="Blog">
+  <!-- ═══════════════ WRITING ═══════════════ -->
+  <section id="blog" class="section" aria-label="Writing">
     <div class="container">
       <header class="section-header" data-animate>
-        <span class="section-tag">Blog</span>
-        <h2 class="section-title">Thoughts &amp; Writing</h2>
-        <p class="section-subtitle">Latest posts</p>
+        <span class="section-tag">Writing</span>
+        <h2 class="section-title">Notes &amp; Thoughts</h2>
       </header>
-      <div class="blog-grid" id="blog-grid"></div>
+      <div class="writing-intro" data-animate>
+        <p class="writing-intro-text">
+          I keep a dedicated writing page where I collect short notes, things I learned while
+          working on AI, computer vision, or augmented reality, and the occasional longer post
+          when something is worth exploring in depth. Nothing too formal — just a place to think
+          out loud.
+        </p>
+        <a href="blog.html" class="btn btn-primary">Go to writing page &rarr;</a>
+      </div>
     </div>
   </section>
 

--- a/scripts/new-post.js
+++ b/scripts/new-post.js
@@ -2,8 +2,11 @@
 'use strict';
 
 /**
- * new-post.js — Convert a Markdown file into a blog post HTML file and register
- * it in data/blog.js.
+ * new-post.js — Convert a Markdown file into a writing-page entry (HTML file)
+ * and register it in data/blog.js.
+ *
+ * Posts appear on the dedicated writing page (blog.html), not on the homepage.
+ * The homepage writing section is a static intro that links to blog.html.
  *
  * Usage:
  *   node scripts/new-post.js path/to/post.md [options]
@@ -17,7 +20,7 @@
  *   ---
  *   title:   "My Post Title"
  *   date:    "2024-12-01"
- *   excerpt: "Short summary shown on the blog index."
+ *   excerpt: "Short summary shown on the writing page."
  *   tag:     "Research"          # badge colour key
  *   readMin: 7                   # estimated read time in minutes
  *   ---
@@ -68,6 +71,9 @@ function printHelp() {
   console.log(`Usage:
   node scripts/new-post.js <markdown-file> [options]
 
+Generates an HTML file and registers the entry in data/blog.js.
+Entries appear on the writing page (blog.html), not on the homepage.
+
 Options:
   -o, --out-dir <dir>   Output directory for HTML (default: blog/)
   --dry-run             Print output without writing files
@@ -76,7 +82,7 @@ Options:
 Frontmatter fields (YAML between --- delimiters):
   title    (required)  Post title
   date     (required)  ISO date, e.g. 2024-12-01
-  excerpt  (required)  Short summary for the blog index card
+  excerpt  (required)  Short summary shown on the writing page (blog.html)
   tag      (required)  Badge label, e.g. Research / Engineering / AI
   readMin  (required)  Estimated reading time in minutes
   lead               Optional opening sentence in large type


### PR DESCRIPTION
- index.html: replace dynamic blog-card grid with a static intro
  paragraph linking to blog.html. The homepage no longer renders
  individual post cards; the dedicated writing page (blog.html) is
  the canonical place for all entries.
- scripts/new-post.js: update top-of-file JSDoc and printHelp() to
  clarify that generated posts appear on blog.html, not the homepage.
- docs/plan-projects.md: new planning document describing the full
  Projects/Portfolio section — data shape, homepage card strip,
  projects.html detail page, new-project.js script, CSS/JS additions,
  implementation order, and open questions.

https://claude.ai/code/session_01JCJctviV4kg31zy43FX6e4