### PR TITLE
draft(projects): add AVATecH and Audience Engagement project drafts

### DIFF
--- a/drafts/audience-engagement.md
+++ b/drafts/audience-engagement.md
@@ -1,0 +1,70 @@
+---
+id:          audience-engagement
+title:       "Multi-modal Audience Engagement Measurement System"
+year:        "2020"
+tags:        "Computer Vision, Multi-modal Sensing, Live Events"
+thumb:       "img/projects/audience-engagement-thumb.svg"
+bg:          "img/projects/audience-engagement-bg.svg"
+description: "A multi-modal system that measures audience engagement at live events by fusing computer vision with WiFi/Bluetooth signal analysis. Designed, implemented, and validated at Vicomtech in 2020, and released as open-source software."
+link_paper:  "https://link.springer.com/chapter/10.1007/978-3-030-71158-0_17"
+link_code:   "https://github.com/tv-vicomtech/AudienceEngagement"
+---
+
+How do you know whether an audience is actually paying attention? For a conference organiser, a museum curator, or a retail-space operator, the question matters: did people show up and engage, or did they walk past? Existing answers relied on either expensive, intrusive sensors or proxy metrics (ticket sales, post-event surveys) that say nothing about what happened in the room.
+
+This project, carried out at **Vicomtech** in **2020** and published at **ICAART 2020** (Sanz-Narrillos, Masneri, Zorrilla — *"A Multi-modal Audience Engagement Measurement System"*), proposed a different answer: combine two cheap, complementary sensing modalities — **computer vision** and **wireless signal strength** — and use each to cover the weaknesses of the other. The complete system was released as open source and is available on [GitHub](https://github.com/tv-vicomtech/AudienceEngagement).
+
+## The Two Modalities
+
+**Visual channel.** Standard RGB cameras feed a pipeline built on **TensorFlow** and **OpenCV**. For each frame the system runs, in sequence:
+
+1. Person detection — locating every individual in the frame.
+2. Face detection inside each person bounding box.
+3. Body-joint estimation — eyes, ears, nose, shoulders, elbows, hands, hips, knees, feet.
+4. Frame-to-frame tracking to maintain stable identities over time.
+5. Attention-direction estimation based on the geometric configuration of the eyes and nose — classified as *front*, *left*, *right*, or *no detection*.
+
+The visual channel answers rich questions (how many people, where, are they looking at the stage?) but fails in poor lighting, behind obstacles, or when the camera simply does not cover a section of the venue.
+
+**Wireless channel.** A network of **Raspberry Pi scanners** passively listens for WiFi and Bluetooth probe requests from devices in the environment. The received signal strength indicator (RSSI) from each scanner, combined across multiple nodes, is used to estimate the approximate location of each device within a set of predefined zones. The processing is done on a central server using the open-source **Find3** framework; scanners and server communicate via **MQTT (Mosquitto)**.
+
+The wireless channel is robust to lighting and occlusions, covers the entire venue regardless of camera placement, and — crucially — provides a **per-device identity** that persists across the event without any cooperation from the attendee.
+
+## Fusion
+
+The two channels produce partially overlapping, partially complementary signals. The visual channel is *precise but narrow*: it tells you exactly who is looking at what, but only where a camera sees them. The wireless channel is *broad but coarse*: it knows someone is in the "main hall" zone, but not their pose or attention. The system fuses both to compute, for each zone and each time window:
+
+- **Occupancy** — how many distinct devices and people were present.
+- **Dwell time** — how long, on average, individuals stayed in the zone.
+- **Attention share** — the fraction of visible people whose gaze was directed towards the designated focal point (stage, screen, exhibit).
+- **Movement patterns** — total and maximum distance travelled, extracted from the visual tracks.
+
+An engagement score is computed by weighting these primitives. The weights are not fixed: they can be tuned per venue and per event type, which matters because "engagement" looks very different at a conference talk (low movement, high attention share) than at a museum exhibit (moderate movement, high dwell time) or a product launch (high movement, variable attention).
+
+## System Architecture
+
+The software stack was designed to be deployable on commodity hardware:
+
+- **Scanner nodes** — Raspberry Pi 3 / 4 units with wireless monitor-mode dongles, written in **Go** for efficiency on constrained hardware.
+- **Server** — Go-based aggregation and inference service, also handling MQTT brokerage.
+- **Vision processing** — Python 3 with TensorFlow and OpenCV; runs on a small GPU-equipped edge machine connected to the venue cameras.
+- **Messaging** — MQTT over Mosquitto for all inter-component communication.
+- **Deployment** — Docker images for each component to simplify installation at the venue.
+
+The deliberate choice of **Go for the wireless side** and **Python for the vision side** reflected practical trade-offs: Go gave us the single-binary deployability and tight memory footprint we needed on the Pi scanners; Python gave us the machine-learning ecosystem for everything visual.
+
+## Evaluation
+
+The system was validated in controlled deployments where ground truth (attendee counts, known positions, attention direction recorded manually) could be compared against the system's output. The paper reports the fusion of both modalities consistently outperforms either modality alone for the composite engagement metric, especially in scenarios where one of the channels degrades (poor lighting for vision, device-dense environments for wireless).
+
+## Why It Mattered
+
+Three things made this project interesting beyond the engagement-metric angle:
+
+1. **Multi-modal sensor fusion done pragmatically.** Academic papers on multi-modal systems often fuse modalities that share a common machine-learning formulation. Here the channels had completely different statistical properties, completely different hardware requirements, and different failure modes. The fusion had to respect that asymmetry.
+
+2. **Open-source release.** The entire stack — scanner firmware, server, vision pipeline, MQTT plumbing, Docker files — is on GitHub and was designed for reproducibility. At the time, very little open tooling existed in the audience-analytics space outside of proprietary, closed commercial offerings.
+
+3. **Privacy-aware by design.** The wireless channel uses **MAC addresses as transient identifiers only**, and all personal identifiers are dropped before aggregation. The visual channel produces only zone-level statistics, not per-person records. This was a deliberate response to the GDPR landscape that was crystallising in Europe in 2019–2020.
+
+The work fed into subsequent research at Vicomtech on **multi-device media services** (IEEE Transactions on Broadcasting, **2021**) and shaped the broader thinking about **adaptive, context-aware media delivery** that I worked on throughout my time there.

--- a/drafts/avatech.md
+++ b/drafts/avatech.md
@@ -1,0 +1,50 @@
+---
+id:          avatech
+title:       "AVATecH: Automated Annotation of Audio/Video Corpora for Humanities Research"
+year:        "2009 – 2014"
+tags:        "Computer Vision, Audio Analysis, Digital Humanities"
+thumb:       "img/projects/avatech-thumb.svg"
+bg:          "img/projects/avatech-bg.svg"
+description: "AVATecH was a joint Fraunhofer / Max Planck project that brought state-of-the-art audio and video pattern recognition into ELAN — the de-facto annotation tool used by linguists, anthropologists, and psychologists worldwide — turning weeks of manual labelling into minutes of supervised review."
+link_paper:  "https://aclanthology.org/L12-1137/"
+---
+
+AVATecH (**A**udio-**V**isual **T**echnology for **H**umanities Research) was a multi-year research project I worked on at **Fraunhofer Heinrich-Hertz-Institut (HHI)** between **2009 and 2014**, in collaboration with the **Max Planck Institute for Psycholinguistics (MPI Nijmegen)** and **Fraunhofer IAIS**. It was my first major research contribution after joining HHI, and it defined the direction of my early career: applying computer vision and audio analysis to problems outside the traditional media-tech industry.
+
+The problem was simple to state and painful to live with. Researchers in linguistics, sign-language studies, child-development psychology, and anthropology depend on annotated audio-visual recordings: transcriptions of speech, boundaries of gestures, phases of interaction, participant labels. Creating those annotations by hand takes between **50 and 100 times the length of the media itself**. A single one-hour field recording could take a PhD student two full weeks to annotate. Corpora of hundreds of hours were common, and every new study needed fresh annotations.
+
+AVATecH set out to reduce that burden by automating the most mechanical parts of the annotation pipeline — not to replace the researcher, but to pre-annotate the material so the human expert could focus on correction and semantic judgement rather than clicking through silent segments of video.
+
+## Approach
+
+The project produced a suite of **audio and video recognizers** — independent, pluggable modules — that were integrated into **ELAN**, the multi-tier annotation tool developed at MPI and used by thousands of humanities researchers worldwide. ELAN was extended with a generic recognizer API described in XML, so each algorithm could be invoked from inside the tool, run on the loaded media, and return tiers of tentative annotations that the user could accept, edit, or reject.
+
+Among the recognizers delivered:
+
+- **Shot-boundary detection** — segmenting raw video into visually coherent units, essential for any downstream analysis of filmed interviews or field recordings.
+- **Speech activity detection** — fine-grained segmentation of audio into speech / non-speech regions, independent of language. Critical for field recordings where languages may be under-documented and no speech-recognition model exists.
+- **Speaker clustering** — grouping speech segments by speaker identity without prior enrollment, so researchers studying turn-taking or dialogue structure could start from automatic speaker diarization.
+- **Lecture and conference video segmentation** — SVM-based structuring of long-form educational recordings, published separately at VISAPP 2014.
+
+The recognizers were designed as **modular components with adaptation and feedback mechanisms**: the researcher's corrections could be fed back into the models, allowing them to adapt to the often unusual acoustic and visual conditions of humanities field data (low-quality recordings, overlapping speech, non-standard camera placements).
+
+## Technical Context
+
+The project ran during a period in which audio and video analysis was transitioning from hand-crafted features to learned representations — pre-deep-learning era. The speech and speaker modules relied on MFCC features, GMM/HMM acoustic models, and clustering algorithms; the video modules used colour histograms, motion vectors, and SVM classifiers. Every recognizer had to run acceptably fast on a standard researcher laptop — no GPUs, no cloud.
+
+Making all of that **integrate cleanly into a tool users already knew and trusted** was as much of the work as the algorithms themselves. ELAN had an established user base and a very specific interaction model; any pre-annotations had to slot into that model without disrupting existing workflows.
+
+## Publications and Impact
+
+The work produced several peer-reviewed papers, including:
+
+- *AVATecH: Audio/Video Technology for Humanities Research* — LREC Workshop on Language Technologies for Digital Humanities, Hissar, Bulgaria, **2011**.
+- *AVATecH — Automated Annotation Through Audio and Video Analysis* — LREC 2012, Istanbul.
+- *Application of Audio and Video Processing Methods for Language Research and Documentation: The AVATecH Project* — book chapter in *Human Language Technology Challenges for Computer Science and Linguistics*, Springer, **2014**.
+- *SVM-based Video Segmentation and Annotation of Lectures and Conferences* — VISAPP **2014**.
+
+The recognizers shipped as part of **ELAN** and remained part of the tool's standard distribution for years. For a young engineer, seeing work that started as algorithm research end up in the daily workflow of humanities researchers in dozens of institutions was a lasting lesson: **the technical contribution matters only as much as its path into the hands of the people who need it**.
+
+## Personal Reflection
+
+AVATecH shaped my approach to every project that followed. The constraints of the problem — messy real-world data, domain experts who are not programmers, a tool ecosystem that already exists, evaluation metrics that must reflect real usefulness rather than benchmark performance — are the same constraints I have met again and again, in AR for education and later in GenAI for enterprise. The specific algorithms have aged (a modern version of almost every recognizer would be built on transformer-based models in a tenth of the code), but the engineering discipline of the project has not.

--- a/drafts/ufc-fighter-tracking.md
+++ b/drafts/ufc-fighter-tracking.md
@@ -1,0 +1,75 @@
+---
+id:          ufc-fighter-tracking
+title:       "UFC Fighter Tracking: Multi-Modal Sensing in the Octagon"
+year:        "2017"
+tags:        "Computer Vision, Sensor Fusion, Sports Analytics"
+thumb:       "img/projects/ufc-octagon-thumb.jpg"
+bg:          "img/projects/ufc-octagon-bg.jpg"
+description: "End-to-end real-time analytics for live UFC events: stereo computer vision in the truss above the octagon, accelerometers in the gloves, GPU inference at the venue, and statistics streamed to fans worldwide. Built at AGT International in 2017 and demoed live by our CEO during Werner Vogels' keynote at AWS re:Invent 2017."
+link_video:  "https://www.youtube.com/watch?v=vataVq9gY_o"
+---
+
+This is the project I tell people about when they ask me what the most fun thing I have ever worked on was. In **2017**, while I was a Senior Data Scientist at **AGT International** in Darmstadt, our team built a real-time fighter-tracking and analytics system for the **UFC**. The product was launched as part of **HEED**, AGT's IoT-driven sports platform, and was presented in a live demonstration by our CEO **Mati Kochavi** during AWS CTO Werner Vogels' keynote at **AWS re:Invent 2017** in Las Vegas — see the [recording on YouTube](https://www.youtube.com/watch?v=vataVq9gY_o).
+
+The brief was straightforward and impossible to fake: produce real-time, broadcast-quality statistics for an MMA fight, generated from the cage itself, with no human operator pressing buttons. The system had to work everywhere the UFC went, install in hours, survive the production environment of a live televised event, and feed numbers into the official mobile app while the fight was still happening.
+
+![UFC octagon from above — camera coverage](img/projects/ufc-octagon-overhead.jpg)
+
+## What We Measured
+
+The output of the system was a continuous stream of statistics for each of the two fighters:
+
+- **Position and speed** — every fighter's location inside the octagon, sampled many times per second.
+- **Octagon control** — which fighter was occupying the centre vs. being pushed against the cage, computed from the relative positions over time.
+- **Total movement** — distance covered by each fighter through a round and across the fight.
+- **Posture state** — *standing* vs. *on the ground*, with transitions timestamped so the broadcast could show "X seconds of ground game".
+- **Strike counts** — kicks and punches, separated by type (jab, hook, uppercut, …) and by *attempted* vs. *landed*.
+
+All of this was published to the cloud, aggregated, and pushed to the consumer-facing UFC app and to broadcast graphics in near real time.
+
+## Hardware in the Truss
+
+Coverage of a UFC octagon — eight sides, fast lateral motion, frequent occlusions when fighters clinched — was the first hard problem. We solved it with **two [Stereolabs ZED](https://www.stereolabs.com/) RGB-D cameras** mounted on the **truss above the cage**, angled to give overlapping fields of view that covered the entire fighting surface. The depth channel was crucial: knowing the distance of each fighter from the camera let us resolve the ambiguities that single RGB streams suffered from, especially during ground exchanges.
+
+Both cameras were cabled to a **GPU-equipped PC, also mounted on the truss**, which performed all the perception work locally. Doing inference at the venue (rather than streaming raw footage to a remote machine) was a deliberate choice — it eliminated the network as a bottleneck, kept latency in the sub-second range, and meant the system kept working even when venue connectivity wobbled. The PC then streamed only the resulting statistics down to the cloud over a much narrower data path.
+
+![Truss-mounted cameras and edge GPU PC](img/projects/ufc-truss-rig.jpg)
+
+## Sensor Fusion: Vision + Accelerometers
+
+Pure vision could detect that a punch had been *thrown*, but not whether it had *connected* — and certainly not the punch *type* with the precision the UFC wanted. The fix was multi-modal: a parallel sensor team had instrumented the fighters' **gloves with accelerometers**, providing a second, completely independent signal for every strike.
+
+We fused the two streams in real time:
+
+- The **vision pipeline** detected the launch of a strike, identified which fighter threw it, and gave a coarse classification of its trajectory.
+- The **accelerometer pipeline** detected the impact event, the magnitude of the deceleration, and the kinematic signature characteristic of different punch types (uppercut, hook, straight).
+- A **fusion layer** matched accelerometer events to vision events by timestamp and fighter ID, and used the combination to decide *hit vs. miss* and to commit a final classification of the punch type.
+
+This is the kind of system that looks obvious in a slide but is fiddly to make work in practice. Clock synchronisation between the camera PC and the wireless sensor receivers had to be tight; the matching window had to be loose enough to absorb jitter but tight enough not to confuse two strikes thrown in quick succession; and the whole pipeline had to fail gracefully when one modality dropped out (a sensor disconnect, a camera momentarily occluded by a referee).
+
+## Cloud and Delivery
+
+Once produced at the edge, the statistics were ingested through **AWS** services (Kinesis for ingestion, downstream services for processing, persistence, and fan-out — see [AGT's separate AWS re:Invent 2017 talk on the Kinesis side of the architecture](https://www.youtube.com/watch?v=zHSEnKb69go)). From there they were relayed to the UFC app and to broadcast partners. The end-to-end latency target was *fast enough that the on-screen number was correct by the time a viewer looked down at it* — a few seconds, not minutes.
+
+## My Role
+
+This was the project where I was involved **end to end**, and I think of it as the moment my career stopped being purely about algorithms:
+
+- **Algorithm design** — I worked on the perception side: detection, tracking, posture classification, and the matching logic that fused vision with the accelerometer stream.
+- **Network and edge architecture** — choices about where computation happened (truss vs. cloud), how data moved between components, and how the system behaved under network degradation.
+- **Product ownership** — translating between what the UFC wanted as a product (clean, interpretable, defensible numbers) and what we could measure as engineers.
+- **Customer-facing point of contact** — direct contact with the UFC and with the third-party sensor team that built the glove instrumentation, coordinating their hardware and our software so the two halves of the system actually shipped as one product.
+- **Live deployment** — I travelled to multiple live events around the world to install, calibrate, and operate the system on fight nights. There is no substitute for standing under the truss while a fight is happening to find out what your software does not handle.
+
+## Why It Was Special
+
+Three things made this project the one I still talk about:
+
+1. **Multi-modality done in earnest.** Computer vision and inertial sensing are completely different beasts statistically and operationally; making them produce a single, coherent stream of statistics was a real engineering problem rather than a checkbox.
+2. **Live events around the world.** I helped run the system at fight nights on multiple continents. Each venue brought its own truss geometry, lighting, network, and crew — and the system had to work in all of them.
+3. **End-to-end ownership.** I touched every layer, from the GPU code on the truss PC to the data contracts with the broadcaster, and I was the person the UFC and the sensor partner picked up the phone to call. That breadth shaped how I work to this day.
+
+## Public Material
+
+- **AWS re:Invent 2017 keynote demo** — Mati Kochavi (AGT/HEED founder) presents the UFC use-case live during Werner Vogels' keynote: [YouTube](https://www.youtube.com/watch?v=vataVq9gY_o)
+- **AWS re:Invent 2017 — AGT uses Amazon Kinesis for IoT Analytics** — companion talk on the cloud architecture: [YouTube](https://www.youtube.com/watch?v=zHSEnKb69go)


### PR DESCRIPTION
- AVATecH (2009-2014, Fraunhofer HHI x MPI Nijmegen): automated
  audio/video annotation recognizers integrated into ELAN for
  humanities research.
- Audience Engagement (2020, Vicomtech): multi-modal system fusing
  computer vision and WiFi/Bluetooth RSSI for live-event engagement
  measurement; open-source release.