### PR TITLE
ci: drop RSS and sitemap generation from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,14 +39,6 @@ jobs:
       - name: Generate globe locations
         run: npm run generate-locations
 
-      # Regenerate rss.xml.
-      - name: Generate RSS feed
-        run: npm run generate-rss -- --base-url https://${{ github.repository_owner }}.github.io
-
-      # Regenerate sitemap.xml.
-      - name: Generate sitemap
-        run: npm run generate-sitemap -- --base-url https://${{ github.repository_owner }}.github.io
-
       # Minify js/main.js → js/main.min.js.
       - name: Minify JavaScript
         run: npm run minify


### PR DESCRIPTION
Both generate-rss and generate-sitemap scripts have been removed from
package.json along with the blog. The build workflow still invoked them,
which would fail the build. Remove those steps to match the current
script set (test, generate-cv, generate-locations, minify).

https://claude.ai/code/session_011xKvY965dMw5Fn8pndytT6