### PR TITLE
Add two new project pages: TRACTION and MPI Brain Research

### DIFF
--- a/data/projects.js
+++ b/data/projects.js
@@ -19,6 +19,26 @@
 
 export const PROJECTS = [
     {
+            id: "mpi-brain-research",
+            title: "MPI for Brain Research: Software for Reptilian Neuroscience",
+            year: "2015 – 2017",
+            tags: ["Scientific Computing","Neuroscience","Data Analysis"],
+            thumb: "img/projects/mpi-brain-thumb.jpeg",
+            bg: "img/projects/mpi-brain-bg.jpeg",
+            description: "Two years as a scientific software developer in Gilles Laurent's department at the Max Planck Institute for Brain Research in Frankfurt, building MATLAB analysis pipelines and R/Shiny web apps for electrophysiologists studying sleep in bearded dragons and visual processing in ex-vivo turtle brains.",
+            url: "projects/mpi-brain-research.html",
+        },
+    {
+            id: "traction",
+            title: "TRACTION: Opera Co-creation for Social Transformation",
+            year: "2020 – 2022",
+            tags: ["Web Application","Co-creation","Social Inclusion"],
+            thumb: "img/projects/traction-thumb.png",
+            bg: "img/projects/traction-bg.jpg",
+            description: "TRACTION was a Horizon 2020 project, coordinated by Vicomtech, that used opera as a vehicle for social inclusion. My work centred on the Co-creation Stage — the real-time distributed performance tool — spanning development, user-requirements gathering, evaluation, and direct engagement with artistic and community partners across Barcelona, Leiria and Ireland.",
+            url: "projects/traction.html",
+        },
+    {
             id: "aroundtheworld",
             title: "ARoundTheWorld: Collaborative AR for Education",
             year: "2024",

--- a/drafts/mpi-brain-research.md
+++ b/drafts/mpi-brain-research.md
@@ -3,8 +3,8 @@ id:          mpi-brain-research
 title:       "MPI for Brain Research: Software for Reptilian Neuroscience"
 year:        "2015 – 2017"
 tags:        "Scientific Computing, Neuroscience, Data Analysis"
-thumb:       "img/projects/mpi-brain-thumb.jpg"
-bg:          "img/projects/mpi-brain-bg.jpg"
+thumb:       "img/projects/mpi-brain-thumb.jpeg"
+bg:          "img/projects/mpi-brain-bg.jpeg"
 description: "Two years as a scientific software developer in Gilles Laurent's department at the Max Planck Institute for Brain Research in Frankfurt, building MATLAB analysis pipelines and R/Shiny web apps for electrophysiologists studying sleep in bearded dragons and visual processing in ex-vivo turtle brains."
 link_paper:  "https://www.science.org/doi/10.1126/science.aaf3621"
 ---
@@ -33,7 +33,7 @@ The headline result is in the paper *"Spatial Information in a Non-retinotopic V
 
 My job description was much more mundane than the science, but it was indispensable to it.
 
-- **MATLAB analysis code.** Most of the lab's electrophysiology pipeline lived in MATLAB. I helped developing scripts and functions depending on the researcher needs
+- **MATLAB analysis code.** Most of the lab's electrophysiology pipeline lived in MATLAB. I helped develop scripts and functions depending on the researcher needs
 - **Web apps in R / Shiny.** Several of the lab's analysis dashboards were built in **R with Shiny**: interactive visualisations of long electrophysiology recordings that let researchers scrub through nights of sleep data, mark interesting events, compare animals, and pull statistics on the fly without having to write a fresh script every time. Building those felt closer to product engineering than to research, and was very much my comfort zone.
 - **Development best practices.** As an expert developer I was tasked with providing training and teaching how to write clean code and apply devops practices that guarantee reproducibility and simplify maintenance of the codebase
 

--- a/drafts/traction.md
+++ b/drafts/traction.md
@@ -3,7 +3,7 @@ id:          traction
 title:       "TRACTION: Opera Co-creation for Social Transformation"
 year:        "2020 – 2022"
 tags:        "Web Application, Co-creation, Social Inclusion"
-thumb:       "img/projects/traction-thumb.jpg"
+thumb:       "img/projects/traction-thumb.png"
 bg:          "img/projects/traction-bg.jpg"
 description: "TRACTION was a Horizon 2020 project, coordinated by Vicomtech, that used opera as a vehicle for social inclusion. My work centred on the Co-creation Stage — the real-time distributed performance tool — spanning development, user-requirements gathering, evaluation, and direct engagement with artistic and community partners across Barcelona, Leiria and Ireland."
 link_demo:    "https://www.traction-project.eu/"

--- a/index.html
+++ b/index.html
@@ -539,7 +539,7 @@
       <header class="section-header" data-animate>
         <span class="section-tag">Projects</span>
         <h2 class="section-title">Things I&rsquo;ve Built</h2>
-        <p class="section-subtitle">Here are some of the projects I have worked on in the past. I am also doing seriously cool stuff at <a href="https://www.mediapro.tv" target="_blank" rel="noopener">Mediapro</a>, but I am not allowed to talk about it just yet.</p>
+        <p class="section-subtitle">Here is a random selection of some of my past projects &mdash; refresh the page to see a different set. I am also doing seriously cool stuff at <a href="https://www.mediapro.tv" target="_blank" rel="noopener">Mediapro</a>, but I am not allowed to talk about it just yet.</p>
       </header>
       <!-- Items injected by JS — data source: PROJECTS in data/projects.js -->
       <div class="projects-grid" id="projects-grid"></div>

--- a/js/globe.js
+++ b/js/globe.js
@@ -334,7 +334,7 @@ export class Globe3D {
      cvs is captured synchronously before any await so that the async
      completion in _buildGlobe() never reads from globals after they may
      have been restored (e.g. in test teardown). */
-  _buildGlobeTexture(rings, cvs) {
+  _buildGlobeTexture(rings, cvs, CT = CanvasTexture) {
     const W = 2048, H = 1024;
     cvs.width = W; cvs.height = H;
     const ctx = cvs.getContext('2d');
@@ -420,7 +420,7 @@ export class Globe3D {
     ctx.lineWidth = 0.9; ctx.strokeStyle = 'rgba(155,242,255,0.95)';
     ctx.beginPath(); ctx.moveTo(0, antY); ctx.lineTo(W, antY); ctx.stroke();
 
-    return new CanvasTexture(cvs);
+    return new CT(cvs);
   }
 
   async _buildGlobe() {
@@ -432,7 +432,10 @@ export class Globe3D {
 
        cvs is captured synchronously before any await so that the async
        continuation never reads stale DOM after test teardown. */
+    /* Both cvs and CT are captured synchronously before any await so that the
+       async continuation never reads stale values after test teardown. */
     const cvs = document.createElement('canvas');
+    const CT  = CanvasTexture;
 
     const mat = new MeshBasicMaterial({
       color: 0xffffff,
@@ -442,13 +445,13 @@ export class Globe3D {
     try {
       const topo  = await getTopoJSON();
       const rings = this._decodeTopoJSON(topo);
-      const tex   = this._buildGlobeTexture(rings, cvs);
+      const tex   = this._buildGlobeTexture(rings, cvs, CT);
       mat.map = tex;
       mat.needsUpdate = true;
     } catch (_) {
       /* Fallback: hand-drawn polygons (stored as [lat,lon] — swap to [lon,lat]) */
       const rings = GLOBE_CONTINENTS.map(pts => pts.map(([lat, lon]) => [lon, lat]));
-      const tex   = this._buildGlobeTexture(rings, cvs);
+      const tex   = this._buildGlobeTexture(rings, cvs, CT);
       mat.map = tex;
       mat.needsUpdate = true;
     }

--- a/js/main.js
+++ b/js/main.js
@@ -744,9 +744,19 @@ function renderProjects() {
   }
 
   // On projects.html (listing page) the grid opts in via data-render="all"
-  // and shows every project. Elsewhere (homepage) we cap the count.
+  // and shows every project. Elsewhere (homepage) we pick a random subset.
   var showAll = grid.getAttribute && grid.getAttribute('data-render') === 'all';
-  var shown = showAll ? PROJECTS : PROJECTS.slice(0, PROJECTS_MAX_HOMEPAGE);
+  var shown;
+  if (showAll) {
+    shown = PROJECTS;
+  } else {
+    var pool = PROJECTS.slice();
+    for (var i = pool.length - 1; i > 0; i--) {
+      var j = Math.floor(Math.random() * (i + 1));
+      var tmp = pool[i]; pool[i] = pool[j]; pool[j] = tmp;
+    }
+    shown = pool.slice(0, PROJECTS_MAX_HOMEPAGE);
+  }
   grid.innerHTML = shown.map(renderProjectCard).join('');
 
   if (!showAll && PROJECTS.length > PROJECTS_MAX_HOMEPAGE) {

--- a/js/three-context.js
+++ b/js/three-context.js
@@ -23,33 +23,44 @@
    `import * as THREE from 'three'`) lets Rollup tree-shake the rest of the
    library out of the production bundle.
    ───────────────────────────────────────────────────────────────────────── */
-import {
-  WebGLRenderer, Scene, PerspectiveCamera,
-  AmbientLight, DirectionalLight, PointLight,
-  Group, Mesh,
-  SphereGeometry, RingGeometry,
-  MeshBasicMaterial, LineBasicMaterial, PointsMaterial,
-  BufferGeometry, BufferAttribute,
-  Points, Line, LineSegments,
-  CanvasTexture,
-  Vector2, Vector3, QuadraticBezierCurve3,
-  Raycaster, Color,
-  AdditiveBlending, BackSide, DoubleSide,
-} from 'three';
-
-const _THREE_NPM = {
-  WebGLRenderer, Scene, PerspectiveCamera,
-  AmbientLight, DirectionalLight, PointLight,
-  Group, Mesh,
-  SphereGeometry, RingGeometry,
-  MeshBasicMaterial, LineBasicMaterial, PointsMaterial,
-  BufferGeometry, BufferAttribute,
-  Points, Line, LineSegments,
-  CanvasTexture,
-  Vector2, Vector3, QuadraticBezierCurve3,
-  Raycaster, Color,
-  AdditiveBlending, BackSide, DoubleSide,
-};
+// Dynamic import so the module loads gracefully when `three` is absent (e.g.
+// in test environments without node_modules). Tests inject a mock via
+// __setThreeForTests before exercising any Three.js-dependent code paths.
+let _THREE_NPM = {};
+try {
+  const m = await import('three');
+  _THREE_NPM = {
+    WebGLRenderer:          m.WebGLRenderer,
+    Scene:                  m.Scene,
+    PerspectiveCamera:      m.PerspectiveCamera,
+    AmbientLight:           m.AmbientLight,
+    DirectionalLight:       m.DirectionalLight,
+    PointLight:             m.PointLight,
+    Group:                  m.Group,
+    Mesh:                   m.Mesh,
+    SphereGeometry:         m.SphereGeometry,
+    RingGeometry:           m.RingGeometry,
+    MeshBasicMaterial:      m.MeshBasicMaterial,
+    LineBasicMaterial:      m.LineBasicMaterial,
+    PointsMaterial:         m.PointsMaterial,
+    BufferGeometry:         m.BufferGeometry,
+    BufferAttribute:        m.BufferAttribute,
+    Points:                 m.Points,
+    Line:                   m.Line,
+    LineSegments:           m.LineSegments,
+    CanvasTexture:          m.CanvasTexture,
+    Vector2:                m.Vector2,
+    Vector3:                m.Vector3,
+    QuadraticBezierCurve3:  m.QuadraticBezierCurve3,
+    Raycaster:              m.Raycaster,
+    Color:                  m.Color,
+    AdditiveBlending:       m.AdditiveBlending,
+    BackSide:               m.BackSide,
+    DoubleSide:             m.DoubleSide,
+  };
+} catch {
+  // three not installed — tests will inject a mock via __setThreeForTests
+}
 
 let _current = _THREE_NPM;
 const _listeners = [];

--- a/projects/mpi-brain-research.html
+++ b/projects/mpi-brain-research.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Two years as a scientific software developer in Gilles Laurent's department at the Max Planck Institute for Brain Research in Frankfurt, building MATLAB analysis pipelines and R/Shiny web apps for electrophysiologists studying sleep in bearded dragons and visual processing in ex-vivo turtle brains." />
+  <meta name="author" content="Stefano Masneri" />
+  <meta name="robots" content="index, follow, noai, noimageai" />
+  <title>MPI for Brain Research: Software for Reptilian Neuroscience — Stefano Masneri</title>
+  <link rel="canonical" href="https://stocastico.github.io/projects/mpi-brain-research.html" />
+
+  <meta property="og:type"        content="article" />
+  <meta property="og:url"         content="https://stocastico.github.io/projects/mpi-brain-research.html" />
+  <meta property="og:title"       content="MPI for Brain Research: Software for Reptilian Neuroscience — Stefano Masneri" />
+  <meta property="og:description" content="Two years as a scientific software developer in Gilles Laurent's department at the Max Planck Institute for Brain Research in Frankfurt, building MATLAB analysis pipelines and R/Shiny web apps for electrophysiologists studying sleep in bearded dragons and visual processing in ex-vivo turtle brains." />
+  <meta property="og:image"       content="https://stocastico.github.io/img/projects/mpi-brain-bg.jpeg" />
+  <meta name="twitter:card"        content="summary_large_image" />
+  <meta name="twitter:title"       content="MPI for Brain Research: Software for Reptilian Neuroscience — Stefano Masneri" />
+  <meta name="twitter:description" content="Two years as a scientific software developer in Gilles Laurent's department at the Max Planck Institute for Brain Research in Frankfurt, building MATLAB analysis pipelines and R/Shiny web apps for electrophysiologists studying sleep in bearded dragons and visual processing in ex-vivo turtle brains." />
+
+  <meta name="theme-color" content="#080c14" />
+
+  <link rel="stylesheet" href="../css/fonts.css" />
+  <link rel="icon"
+    href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%23080c14'/%3E%3Ctext x='50%25' y='56%25' text-anchor='middle' font-size='32' fill='%2300d4ff' font-family='Georgia,serif'%3ESM%3C/text%3E%3C/svg%3E" />
+  <link rel="stylesheet" href="../css/styles.css" />
+</head>
+<body>
+  <div class="reading-progress" id="reading-progress" aria-hidden="true"></div>
+  <a class="skip-link" href="#project-content">Skip to project</a>
+
+  <nav id="navbar" role="navigation" aria-label="Main navigation">
+    <div class="nav-inner">
+      <a href="../index.html" class="nav-logo" aria-label="Home">
+        <svg class="nav-home-icon" viewBox="0 0 24 24" fill="none" stroke="url(#nav-grad)" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <defs>
+            <linearGradient id="nav-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stop-color="#6c63ff"/>
+              <stop offset="100%" stop-color="#00d4ff"/>
+            </linearGradient>
+          </defs>
+          <path d="M3 9.5L12 3l9 6.5V21a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V9.5z"/>
+          <path d="M9 22V12h6v10"/>
+        </svg>
+      </a>
+      <button class="nav-toggle" id="nav-toggle" aria-expanded="false" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+      <ul class="nav-links" id="nav-links">
+        <li><a href="../index.html#about">About</a></li>
+        <li><a href="../index.html#research">Work</a></li>
+        <li><a href="../projects.html">Projects</a></li>
+        <li><a href="../index.html#contact">Contact</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <!-- Project hero banner (semi-transparent image + title overlay) -->
+  <header class="project-hero" style="--project-hero-img: url('../img/projects/mpi-brain-bg.jpeg');" aria-label="MPI for Brain Research: Software for Reptilian Neuroscience">
+    <div class="project-hero__overlay" aria-hidden="true"></div>
+    <div class="project-hero__inner">
+      <p class="post-back-row">
+        <a href="../projects.html" class="cv-back-link">&larr; All projects</a>
+      </p>
+      <p class="project-detail__year">2015 – 2017</p>
+      <h1 class="project-detail__title">MPI for Brain Research: Software for Reptilian Neuroscience</h1>
+      <div class="project-detail__tags">
+        <span class="project-tag">Scientific Computing</span>
+        <span class="project-tag">Neuroscience</span>
+        <span class="project-tag">Data Analysis</span>
+      </div>
+    </div>
+  </header>
+
+  <main id="project-content" class="post">
+    <div class="post-lead">Two years as a scientific software developer in Gilles Laurent's department at the Max Planck Institute for Brain Research in Frankfurt, building MATLAB analysis pipelines and R/Shiny web apps for electrophysiologists studying sleep in bearded dragons and visual processing in ex-vivo turtle brains.</div>
+
+    <p>
+Between <strong>2015 and 2017</strong> I worked as a <strong>Scientific Software Developer</strong> at the <strong>Max Planck Institute for Brain Research</strong> in Frankfurt, in the department led by <strong>Prof. Gilles Laurent</strong>. I want to be precise about my role from the start: I was <strong>not a researcher</strong> there. I did not run experiments, design studies, or co-author the papers that came out of the lab. I was the engineer who sat next to the people doing all of that, and helped them turn their data into something they could actually look at.
+</p>
+<p>
+What made the place extraordinary was the science the researchers were doing around me. The Laurent lab studies the function and dynamics of neuronal circuits, with a particular interest in <strong>non-mammalian vertebrates</strong> — reptiles and cephalopods — as windows into the deep evolutionary origins of the brain. In the two years I was there, I had a front-row seat to two projects that I still describe to people whenever the conversation turns to &quot;the most interesting thing you've ever worked on&quot;.
+</p>
+<h2>Sleep in Bearded Dragons</h2>
+<p>
+The first was the Pogona sleep work. <em>Pogona vitticeps</em>, the <strong>Australian central bearded dragon</strong>, was the unlikely star of the lab. For decades, the textbook story had been that the two sleep states familiar to us — <strong>slow-wave sleep</strong> and <strong>REM sleep</strong> — were a mammalian (and avian) invention. Reptiles slept, but they did not have those characteristic alternating brain rhythms. Or so it was thought.
+</p>
+<p>
+To test this properly, the experimental team needed long, continuous, high-quality recordings from the brains of awake and sleeping animals. The setup was very cool and straight from science fiction (at least for me): the dragons were fitted with what we called <strong>&quot;the hat&quot;</strong>: a small custom-built headstage cemented to the skull, from which thin cables emerged carrying signals from <strong>silicon probes implanted deep in the brain</strong> (in the dorsal ventricular ridge, the reptilian analogue of cortex). The animals lived their normal lives in their tanks while the system recorded <strong>for weeks at a time</strong>, capturing every nap, every overnight sleep cycle, every transition between states.
+</p>
+<p>
+The signals revealed two regular oscillating brain states alternating with a period of roughly <strong>80 seconds</strong>, repeating for <strong>6 to 10 hours every night</strong> — the reptilian equivalents of slow-wave and REM sleep. The paper, <em>&quot;Slow waves, sharp waves, ripples, and REM in sleeping dragons&quot;</em>, appeared in <strong>Science</strong> in 2016 and pushed the likely evolutionary origin of these sleep dynamics back at least to the common amniote ancestor of mammals, birds, and reptiles, more than 300 million years ago.
+</p>
+<h2>Moving Images in a Turtle Brain on a Slide</h2>
+<p>
+The second project was, if anything, even stranger. The lab also worked on the <strong>visual cortex of the turtle</strong>. Turtle brain tissue has an unusual property that makes it priceless to neuroscientists: <strong>it remains alive and electrophysiologically active for days after the animal is sacrificed</strong>, kept in oxygenated artificial cerebrospinal fluid. This is much harder to do with mammalian tissue, which deteriorates quickly.
+</p>
+<p>
+The researchers exploited this to build something that on first hearing sounds vaguely science-fiction. They prepared <strong>whole isolated turtle brains, with the eyes still attached via the optic nerve</strong>, in a recording chamber. They then <strong>showed moving visual stimuli to the eyes of the disembodied preparation</strong> — drifting bars, gratings, natural scenes — and recorded from the cortex as the visual signals propagated in. In other preparations they worked with brain slices in which the visual cortex was still wired up enough to respond to direct stimulation.
+</p>
+<p>
+The headline result is in the paper <em>&quot;Spatial Information in a Non-retinotopic Visual Cortex&quot;</em> (Fournier, Müller, Schneider, Hemberger, and Laurent, <em>Neuron</em>, 2018), based on data collected in the period I was there. It showed that the turtle visual cortex represents space in a way that is <strong>not retinotopic</strong> — neighbouring points in the visual field are not represented by neighbouring neurons, in contrast to mammalian primary visual cortex. Instead, spatial information is distributed across the cortex in a more mixed, sequence-like fashion. It is one of those findings that quietly destabilises the neat picture in the textbooks.
+</p>
+<h2>What I Actually Did</h2>
+<p>
+My job description was much more mundane than the science, but it was indispensable to it.
+</p>
+<ul>
+  <li><strong>MATLAB analysis code.</strong> Most of the lab's electrophysiology pipeline lived in MATLAB. I helped develop scripts and functions depending on the researcher needs</li>
+  <li><strong>Web apps in R / Shiny.</strong> Several of the lab's analysis dashboards were built in <strong>R with Shiny</strong>: interactive visualisations of long electrophysiology recordings that let researchers scrub through nights of sleep data, mark interesting events, compare animals, and pull statistics on the fly without having to write a fresh script every time. Building those felt closer to product engineering than to research, and was very much my comfort zone.</li>
+  <li><strong>Development best practices.</strong> As an expert developer I was tasked with providing training and teaching how to write clean code and apply devops practices that guarantee reproducibility and simplify maintenance of the codebase</li>
+</ul>
+<h2>Personal Reflection</h2>
+<p>
+It was the only stretch of my career spent embedded in an academic neuroscience environment, and it shaped me more than the line on my CV suggests. Watching the researchers <strong>frame questions, design experiments, argue at lab meetings, and refuse to overinterpret a clean-looking plot</strong> was a quiet education in scientific taste — the kind of taste that does not transfer to engineering directly but informs it permanently.
+</p>
+<p>
+It also clarified something about my own preferences. I love being close to research. I also love shipping things that other people use. The role of <em>scientific software developer</em> — not a PI, not a postdoc, but the engineer who makes the science move faster — is a genuinely good (and difficult!) role, and one that I think research institutes generally underinvest in.
+</p>
+
+      <div class="project-links">
+        <a href="https://www.science.org/doi/10.1126/science.aaf3621" target="_blank" rel="noopener">Paper</a>
+      </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <p>&copy; <span id="footer-year"></span> Stefano Masneri &nbsp;&middot;&nbsp; Built with <a href="https://claude.ai" target="_blank" rel="noopener">Claude</a>, <a href="https://threejs.org" target="_blank" rel="noopener">Three.js</a> &amp; <a href="https://github.com/Stocastico/stocastico.github.io" target="_blank" rel="noopener">GitHub</a> in San Sebasti&aacute;n</p>
+    </div>
+  </footer>
+
+  <button class="back-to-top" id="back-to-top" aria-label="Back to top">
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M12 19V5M5 12l7-7 7 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+  </button>
+
+  <script type="module" src="/js/main.js"></script>
+</body>
+</html>

--- a/projects/traction.html
+++ b/projects/traction.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="TRACTION was a Horizon 2020 project, coordinated by Vicomtech, that used opera as a vehicle for social inclusion. My work centred on the Co-creation Stage — the real-time distributed performance tool — spanning development, user-requirements gathering, evaluation, and direct engagement with artistic and community partners across Barcelona, Leiria and Ireland." />
+  <meta name="author" content="Stefano Masneri" />
+  <meta name="robots" content="index, follow, noai, noimageai" />
+  <title>TRACTION: Opera Co-creation for Social Transformation — Stefano Masneri</title>
+  <link rel="canonical" href="https://stocastico.github.io/projects/traction.html" />
+
+  <meta property="og:type"        content="article" />
+  <meta property="og:url"         content="https://stocastico.github.io/projects/traction.html" />
+  <meta property="og:title"       content="TRACTION: Opera Co-creation for Social Transformation — Stefano Masneri" />
+  <meta property="og:description" content="TRACTION was a Horizon 2020 project, coordinated by Vicomtech, that used opera as a vehicle for social inclusion. My work centred on the Co-creation Stage — the real-time distributed performance tool — spanning development, user-requirements gathering, evaluation, and direct engagement with artistic and community partners across Barcelona, Leiria and Ireland." />
+  <meta property="og:image"       content="https://stocastico.github.io/img/projects/traction-bg.jpg" />
+  <meta name="twitter:card"        content="summary_large_image" />
+  <meta name="twitter:title"       content="TRACTION: Opera Co-creation for Social Transformation — Stefano Masneri" />
+  <meta name="twitter:description" content="TRACTION was a Horizon 2020 project, coordinated by Vicomtech, that used opera as a vehicle for social inclusion. My work centred on the Co-creation Stage — the real-time distributed performance tool — spanning development, user-requirements gathering, evaluation, and direct engagement with artistic and community partners across Barcelona, Leiria and Ireland." />
+
+  <meta name="theme-color" content="#080c14" />
+
+  <link rel="stylesheet" href="../css/fonts.css" />
+  <link rel="icon"
+    href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%23080c14'/%3E%3Ctext x='50%25' y='56%25' text-anchor='middle' font-size='32' fill='%2300d4ff' font-family='Georgia,serif'%3ESM%3C/text%3E%3C/svg%3E" />
+  <link rel="stylesheet" href="../css/styles.css" />
+</head>
+<body>
+  <div class="reading-progress" id="reading-progress" aria-hidden="true"></div>
+  <a class="skip-link" href="#project-content">Skip to project</a>
+
+  <nav id="navbar" role="navigation" aria-label="Main navigation">
+    <div class="nav-inner">
+      <a href="../index.html" class="nav-logo" aria-label="Home">
+        <svg class="nav-home-icon" viewBox="0 0 24 24" fill="none" stroke="url(#nav-grad)" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <defs>
+            <linearGradient id="nav-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stop-color="#6c63ff"/>
+              <stop offset="100%" stop-color="#00d4ff"/>
+            </linearGradient>
+          </defs>
+          <path d="M3 9.5L12 3l9 6.5V21a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V9.5z"/>
+          <path d="M9 22V12h6v10"/>
+        </svg>
+      </a>
+      <button class="nav-toggle" id="nav-toggle" aria-expanded="false" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+      <ul class="nav-links" id="nav-links">
+        <li><a href="../index.html#about">About</a></li>
+        <li><a href="../index.html#research">Work</a></li>
+        <li><a href="../projects.html">Projects</a></li>
+        <li><a href="../index.html#contact">Contact</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <!-- Project hero banner (semi-transparent image + title overlay) -->
+  <header class="project-hero" style="--project-hero-img: url('../img/projects/traction-bg.jpg');" aria-label="TRACTION: Opera Co-creation for Social Transformation">
+    <div class="project-hero__overlay" aria-hidden="true"></div>
+    <div class="project-hero__inner">
+      <p class="post-back-row">
+        <a href="../projects.html" class="cv-back-link">&larr; All projects</a>
+      </p>
+      <p class="project-detail__year">2020 – 2022</p>
+      <h1 class="project-detail__title">TRACTION: Opera Co-creation for Social Transformation</h1>
+      <div class="project-detail__tags">
+        <span class="project-tag">Web Application</span>
+        <span class="project-tag">Co-creation</span>
+        <span class="project-tag">Social Inclusion</span>
+      </div>
+    </div>
+  </header>
+
+  <main id="project-content" class="post">
+    <div class="post-lead">TRACTION was a Horizon 2020 project, coordinated by Vicomtech, that used opera as a vehicle for social inclusion. My work centred on the Co-creation Stage — the real-time distributed performance tool — spanning development, user-requirements gathering, evaluation, and direct engagement with artistic and community partners across Barcelona, Leiria and Ireland.</div>
+
+    <p>
+TRACTION (<em>Opera co-creation for a social transformation</em>) was a three-year EU Horizon 2020 research and innovation action that ran from <strong>January 2020 to December 2022</strong>, coordinated by <strong>Vicomtech</strong> and with a total budget of roughly <strong>€3.75M</strong>. The project set out to do something deceptively simple: take opera — an art form often perceived as elitist and inaccessible — and turn it back into a vehicle for social and cultural inclusion, by giving marginalised communities the tools to <strong>co-create</strong> opera performances alongside professional artists.
+</p>
+<p>
+That ambition was tested in three very different places: the inner-city neighbourhoods of <strong>Barcelona</strong> (Raval), a youth prison in <strong>Leiria, Portugal</strong>, and the rural communities of <strong>Ireland</strong>. The technological backbone of the project was a pair of digital platforms developed at Vicomtech and CWI: the <strong>Co-creation Space</strong> and the <strong>Co-creation Stage</strong>.
+</p>
+<h2>My Role</h2>
+<p>
+My main contribution was to the <strong>Co-creation Stage</strong> — the real-time distributed performance tool that allowed a single opera to be staged simultaneously across multiple co-located venues, synchronising live video, audio and interaction between stages. I was involved across the full lifecycle, in a role that combined technical development with research and partnership activities:
+</p>
+<ul>
+  <li><strong>Development</strong>: working on both the frontend and the backend of the Stage, contributing to the low-latency adaptive media transmission layer that made synchronised live performance across venues possible.</li>
+  <li><strong>User-requirements gathering</strong>: working closely with the artistic partners — Liceu in Barcelona, SAMP in Leiria, Irish National Opera in Ireland — and with sociologists and community educators to translate what professional artists and community participants actually needed into concrete software features.</li>
+  <li><strong>Evaluation</strong>: designing and running usability studies and field trials, collecting and analysing feedback, and feeding findings back into the design and development loop.</li>
+  <li><strong>Partner engagement</strong>: maintaining ongoing dialogue with consortium partners across research, opera, education and prison-work organisations in five countries, bridging the gap between technical decisions and the realities of the artistic and community use cases.</li>
+</ul>
+<p>
+The Co-creation Stage was the centrepiece of the live-performance moments: a production could be co-presented from a main opera house and from community sites at the same time, dissolving the traditional boundary between professional stage and audience or participant.
+</p>
+<h2>Tech Stack</h2>
+<p>
+The Co-creation Stage is a real-time distributed performance application:
+</p>
+<ul>
+  <li><strong>Frontend</strong> — Angular with TypeScript, designed for multi-venue operator interfaces and audience-facing views.</li>
+  <li><strong>Backend</strong> — low-latency adaptive media transmission to synchronise live video and audio across geographically separated stages in real time.</li>
+  <li><strong>Deployment</strong> — containerised services orchestrated to support live events with strict latency requirements.</li>
+</ul>
+<p>
+The companion <strong>Co-creation Space</strong> — the asynchronous collaboration platform built mainly by colleagues — used a different stack (Node.js / TypeScript / Express backend; React / Redux frontend; PostgreSQL + MongoDB for storage; AWS S3 + Elastic Transcoder for media; WebSockets for real-time notifications) and was designed for the ongoing creative process between live events.
+</p>
+<h2>Outcomes</h2>
+<p>
+By the end of the project, the two tools had supported three full community opera productions across <strong>eleven locations</strong>, engaging over <strong>1,300 non-professional artists</strong>, reaching more than <strong>8,000 live audience members</strong> across six languages, and registering more than <strong>20,000 user interactions</strong> on the platforms.
+</p>
+<ul>
+  <li>In <strong>Barcelona</strong>, <a href="https://www.liceubarcelona.cat/en/liceu-apropa/la-gata-perduda"><em>La Gata Perduda</em></a> was performed twice at the Liceu Opera House to sold-out audiences in October 2022, with a choir formed from twelve amateur choirs from the Raval. The Catalan public broadcast reached around 766,000 viewers. The <a href="https://www.traction-project.eu/trials/liceu/">TRACTION project page for the Liceu trial</a> documents the full co-creation process behind the production.</li>
+  <li>In <strong>Leiria</strong>, <em>O Tempo (Somos Nós)</em> — produced with SAMP and the young inmates, their relatives and prison workers — was performed four times in June 2022: twice inside the prison and twice at the Gulbenkian's main concert hall in Lisbon.</li>
+  <li>In <strong>Ireland</strong>, <em>Out of the Ordinary / As an nGnách</em> became the world's first virtual reality community opera, co-created with rural teenagers and toured around the country.</li>
+</ul>
+<p>
+Survey data from participants reported that 94% felt actively involved, 89% learned from others, and 75% reported improved well-being.
+</p>
+<h2>Social Implications</h2>
+<p>
+What stayed with me long after the project finished is what the technology <em>enabled</em> rather than what the technology <em>was</em>. A platform for sharing videos, comments and audio clips is, in pure software terms, not a remarkable thing. But put it in the hands of a teenager in a juvenile detention centre who has spent years being told their voice does not matter, and the same software becomes a way to record a song that ends up performed at the Gulbenkian concert hall in front of their family. Put it in the hands of a migrant choir in Raval, and it becomes the connective tissue of an opera that fills the Liceu.
+</p>
+<p>
+That is also where the responsibility of the technical role becomes very tangible: every design choice — what is private and what is shared, who can comment on what, how reliable the upload is on a tablet on a slow connection inside a prison — has consequences that go far beyond a usability metric. Building software that is going to be used in those settings requires a different kind of attention than building software for a generic &quot;user&quot;.
+</p>
+
+      <div class="project-links">
+        <a href="https://ieeexplore.ieee.org/abstract/document/9828558" target="_blank" rel="noopener">Paper</a>
+        <a href="https://www.traction-project.eu/" target="_blank" rel="noopener">Demo</a>
+      </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <p>&copy; <span id="footer-year"></span> Stefano Masneri &nbsp;&middot;&nbsp; Built with <a href="https://claude.ai" target="_blank" rel="noopener">Claude</a>, <a href="https://threejs.org" target="_blank" rel="noopener">Three.js</a> &amp; <a href="https://github.com/Stocastico/stocastico.github.io" target="_blank" rel="noopener">GitHub</a> in San Sebasti&aacute;n</p>
+    </div>
+  </footer>
+
+  <button class="back-to-top" id="back-to-top" aria-label="Back to top">
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M12 19V5M5 12l7-7 7 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+  </button>
+
+  <script type="module" src="/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
This PR adds two new project detail pages to the portfolio, along with supporting updates to the project data structure and rendering logic.

## Key Changes

- **New Project Pages**
  - `projects/traction.html`: Detailed case study of the TRACTION Horizon 2020 project on opera co-creation for social inclusion (2020–2022), covering the Co-creation Stage platform, tech stack, outcomes, and social implications
  - `projects/mpi-brain-research.html`: Portfolio piece documenting work as a scientific software developer at the Max Planck Institute for Brain Research (2015–2017), including MATLAB pipelines and R/Shiny applications for neuroscience research

- **Data Structure Updates**
  - Added two new project entries to `data/projects.js` with metadata (title, year, tags, thumbnails, descriptions, URLs)
  - Updated draft markdown files with corrected image file extensions (.jpeg instead of .jpg)

- **Rendering Logic Improvements**
  - Modified `js/main.js` to randomize project selection on the homepage instead of always showing the first N projects, providing better visibility for all portfolio items
  - Updated `js/globe.js` to accept `CanvasTexture` as a parameter in `_buildGlobeTexture()`, improving testability by allowing dependency injection and preventing stale references after test teardown

- **Module Loading Robustness**
  - Changed `js/three-context.js` from static import to dynamic async import with graceful fallback, allowing the module to load in test environments where Three.js may not be installed

## Implementation Details

Both new project pages follow the existing portfolio template structure with:
- Semantic HTML5 with proper accessibility attributes
- Open Graph and Twitter Card metadata for social sharing
- Responsive navigation and footer
- Project hero banner with background imagery
- Detailed narrative content with sections, lists, and external links
- Back-to-top button and reading progress indicator

The homepage project grid now uses Fisher-Yates shuffle to randomly select which projects to display, ensuring all portfolio items get equal exposure across visits.

https://claude.ai/code/session_01FGqtG7FBtY6ZgR7vVcdh3b