### PR TITLE
fix: revert three-context.js to static import to restore DOMContentLoaded timing

### DIFF
--- a/js/three-context.js
+++ b/js/three-context.js
@@ -23,44 +23,33 @@
    `import * as THREE from 'three'`) lets Rollup tree-shake the rest of the
    library out of the production bundle.
    ───────────────────────────────────────────────────────────────────────── */
-// Dynamic import so the module loads gracefully when `three` is absent (e.g.
-// in test environments without node_modules). Tests inject a mock via
-// __setThreeForTests before exercising any Three.js-dependent code paths.
-let _THREE_NPM = {};
-try {
-  const m = await import('three');
-  _THREE_NPM = {
-    WebGLRenderer:          m.WebGLRenderer,
-    Scene:                  m.Scene,
-    PerspectiveCamera:      m.PerspectiveCamera,
-    AmbientLight:           m.AmbientLight,
-    DirectionalLight:       m.DirectionalLight,
-    PointLight:             m.PointLight,
-    Group:                  m.Group,
-    Mesh:                   m.Mesh,
-    SphereGeometry:         m.SphereGeometry,
-    RingGeometry:           m.RingGeometry,
-    MeshBasicMaterial:      m.MeshBasicMaterial,
-    LineBasicMaterial:      m.LineBasicMaterial,
-    PointsMaterial:         m.PointsMaterial,
-    BufferGeometry:         m.BufferGeometry,
-    BufferAttribute:        m.BufferAttribute,
-    Points:                 m.Points,
-    Line:                   m.Line,
-    LineSegments:           m.LineSegments,
-    CanvasTexture:          m.CanvasTexture,
-    Vector2:                m.Vector2,
-    Vector3:                m.Vector3,
-    QuadraticBezierCurve3:  m.QuadraticBezierCurve3,
-    Raycaster:              m.Raycaster,
-    Color:                  m.Color,
-    AdditiveBlending:       m.AdditiveBlending,
-    BackSide:               m.BackSide,
-    DoubleSide:             m.DoubleSide,
-  };
-} catch {
-  // three not installed — tests will inject a mock via __setThreeForTests
-}
+import {
+  WebGLRenderer, Scene, PerspectiveCamera,
+  AmbientLight, DirectionalLight, PointLight,
+  Group, Mesh,
+  SphereGeometry, RingGeometry,
+  MeshBasicMaterial, LineBasicMaterial, PointsMaterial,
+  BufferGeometry, BufferAttribute,
+  Points, Line, LineSegments,
+  CanvasTexture,
+  Vector2, Vector3, QuadraticBezierCurve3,
+  Raycaster, Color,
+  AdditiveBlending, BackSide, DoubleSide,
+} from 'three';
+
+const _THREE_NPM = {
+  WebGLRenderer, Scene, PerspectiveCamera,
+  AmbientLight, DirectionalLight, PointLight,
+  Group, Mesh,
+  SphereGeometry, RingGeometry,
+  MeshBasicMaterial, LineBasicMaterial, PointsMaterial,
+  BufferGeometry, BufferAttribute,
+  Points, Line, LineSegments,
+  CanvasTexture,
+  Vector2, Vector3, QuadraticBezierCurve3,
+  Raycaster, Color,
+  AdditiveBlending, BackSide, DoubleSide,
+};
 
 let _current = _THREE_NPM;
 const _listeners = [];


### PR DESCRIPTION
The previous PR introduced top-level `await import('three')` in three-context.js
to handle missing `three` in test environments. This had a critical side-effect:
top-level await in a module suspends the entire module graph, causing
DOMContentLoaded to fire *before* main.js registers its listener — so
initScrollReveal, renderPublications, renderProjects and all other init calls
never ran. All [data-animate] sections stayed at opacity:0 and dynamic
content (publications, projects) was never injected.

Revert to the original static import. The `three` package is a regular
dependency (not devDep), so it is always present; all 212 tests still pass.

https://claude.ai/code/session_01W9FEuCbTyG7L2hp6ptTRZF