### PR TITLE
fix: restore missing content and globe/map borders

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -30,10 +30,30 @@ function copyDocsPdfs() {
   };
 }
 
+/* Copy data/*.json into dist/data/ — globe.js fetches world-110m.json and
+   europe-map.js fetches land-50m.json at runtime via fetch(), so they are
+   not in the Rollup module graph and Vite won't include them automatically. */
+function copyDataJson() {
+  return {
+    name: 'copy-data-json',
+    apply: 'build',
+    closeBundle() {
+      const srcDir = resolve(__dirname, 'data');
+      const outDir = resolve(__dirname, 'dist', 'data');
+      mkdirSync(outDir, { recursive: true });
+      for (const f of readdirSync(srcDir)) {
+        if (f.toLowerCase().endsWith('.json')) {
+          copyFileSync(resolve(srcDir, f), resolve(outDir, f));
+        }
+      }
+    },
+  };
+}
+
 export default defineConfig({
   base: '/',
   appType: 'mpa',
-  plugins: [copyDocsPdfs()],
+  plugins: [copyDocsPdfs(), copyDataJson()],
   build: {
     outDir: 'dist',
     emptyOutDir: true,


### PR DESCRIPTION
## Summary

Two bugs introduced by PR #62 that together caused no content to appear below the hero and the globe/map to have no borders.

- **`js/three-context.js`** — reverts the dynamic `await import('three')` back to a static import. The top-level `await` was suspending the entire module graph, causing `DOMContentLoaded` to fire before `main.js` ever registered its listener — so `initScrollReveal`, `renderPublications`, `renderProjects` and every other init call never ran, leaving all `[data-animate]` sections at `opacity: 0` and the dynamic content grids empty.
- **`vite.config.js`** — adds a `copyDataJson` plugin (same pattern as the existing `copyDocsPdfs` one) to copy `data/*.json` into `dist/data/` at build time. `globe.js` fetches `world-110m.json` and `europe-map.js` fetches `land-50m.json` at runtime via `fetch()`, but because they are not imported in the module graph Vite was silently omitting them from the production bundle, causing 404s and missing country borders.

## Test plan

- [ ] All 212 tests pass (`npm test`)
- [ ] `npm run build` completes without errors and `dist/data/world-110m.json` + `dist/data/land-50m.json` are present
- [ ] Homepage sections (About, Research, Skills, Publications, Projects, Contact) are all visible after load
- [ ] 3D globe renders with continent outlines
- [ ] 2D Europe map renders with country borders

https://claude.ai/code/session_01W9FEuCbTyG7L2hp6ptTRZF

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9FEuCbTyG7L2hp6ptTRZF)_