### PR TITLE
fix: enlarge profile photo on portrait phones

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2383,6 +2383,18 @@ h3 {
   .hero-name { text-align: center; }
   .hero-name-canvas { left: 50%; transform: translateX(-50%); }
   .hero-actions { justify-content: center; }
+
+  /* Portrait phones: revert .about-photo-col to a column so the profile
+     photo gets the full content width instead of being squeezed next to
+     the stats grid (which collapses it to a sliver below ~400px). */
+  .about-photo-col {
+    flex-direction: column;
+    align-items: center;
+  }
+  .about-photo-col .photo-card {
+    max-width: 260px;
+    width: 100%;
+  }
 }
 
 @media (max-width: 480px) {

--- a/test/playwright.iphone.test.mjs
+++ b/test/playwright.iphone.test.mjs
@@ -270,6 +270,26 @@ console.log('── iPhone SE (375×667, touch, Safari UA) ───────
     );
   });
 
+  // Bug 9: on portrait iPhone widths the about-section profile photo was
+  // capped at 180px while sitting in a row next to the 3-up stats grid,
+  // making it look tiny.  The photo card should render at a comfortable
+  // size (>=220px wide) on a 375px-wide viewport.
+  await test('about-section photo-card is reasonably sized on portrait iPhone', async () => {
+    await page.evaluate(() => document.getElementById('about')?.scrollIntoView());
+    await page.waitForTimeout(300);
+    const m = await page.evaluate(() => {
+      const card = document.querySelector('.about-photo-col .photo-card');
+      if (!card) return null;
+      const rect = card.getBoundingClientRect();
+      return { width: Math.round(rect.width), height: Math.round(rect.height) };
+    });
+    assert(m, '.about-photo-col .photo-card not found');
+    assert(
+      m.width >= 220,
+      `photo-card too small on portrait iPhone: rendered ${m.width}px wide (expected >=220)`,
+    );
+  });
+
   // Bug 7: tap targets for inline tag-pills should be >=32px tall on touch
   // devices (Apple HIG suggests 44, but inline pills can be smaller; we
   // enforce a softer 32 to ensure reasonable touch comfort).


### PR DESCRIPTION
On viewports <=680px, .about-photo-col was still in flex-row mode from
the 1024px breakpoint, with the photo capped at 180px and no min-width.
Combined with the 3-up stats grid taking flex:1, the photo collapsed to
a sliver (~2px) on a 375px iPhone in portrait. Switch the column back
to flex-direction:column at <=680px and let .photo-card fill up to
260px so the photo gets the full content width.

Adds a Playwright iPhone-SE regression test asserting the photo-card
renders >=220px wide on a 375px viewport.

https://claude.ai/code/session_01MmBsqiMa36n6QN1wrgFNeh