### PR TITLE
fix(globe): rimuovi cerchi paralleli spuri e disegna l'Antartide reale

### DIFF
--- a/js/globe.js
+++ b/js/globe.js
@@ -357,11 +357,6 @@ export class Globe3D {
     /* lon, lat → canvas pixel (equirectangular) */
     const px = (lon, lat) => [(lon + 180) / 360 * W, (90 - lat) / 180 * H];
 
-    /* Antarctica: filled band at bottom of map */
-    const antY = (90 - (-68)) / 180 * H;
-    ctx.fillStyle = '#0e2640';
-    ctx.fillRect(0, antY, W, H - antY);
-
     /* Make a ring's longitudes continuous: when consecutive points jump by
        more than 180° they're really crossing the antimeridian, so unwrap by
        ±360°. Without this, drawing the ring on the equirectangular texture
@@ -381,12 +376,16 @@ export class Globe3D {
       return out;
     };
 
-    /* Draw one ring with a multi-pass neon glow stroke */
+    /* Draw one ring with a multi-pass neon glow stroke. Pole-enclosing rings
+       (odd number of antimeridian crossings — Antarctica is the only one in
+       Natural-Earth 110m) are filled by bridging to the relevant pole; their
+       stroke skips that bridge so the coastline stays the only visible edge. */
     const drawRing = ring => {
-      /* Antarctica's single ring encloses the south pole, so it can't be
-         flattened cleanly into a 2D rectangle without bridging to lat=-90.
-         The antY band above already covers it — skip the detailed polygon. */
-      if (ring.some(p => p[1] < -65)) return;
+      let crossings = 0;
+      for (let i = 1; i < ring.length; i++) {
+        if (Math.abs(ring[i][0] - ring[i - 1][0]) > 180) crossings++;
+      }
+      const polar = (crossings % 2) === 1;
 
       const unwrapped = unwrapRing(ring);
       let minLon = Infinity, maxLon = -Infinity;
@@ -395,7 +394,14 @@ export class Globe3D {
         if (p[0] > maxLon) maxLon = p[0];
       }
 
+      let pole = 0;
+      if (polar) {
+        const avgLat = ring.reduce((s, p) => s + p[1], 0) / ring.length;
+        pole = avgLat < 0 ? -90 : 90;
+      }
+
       const drawAt = (shift) => {
+        /* Fill path: coastline + bridge to the pole when polar. */
         ctx.beginPath();
         const [x0, y0] = px(unwrapped[0][0] + shift, unwrapped[0][1]);
         ctx.moveTo(x0, y0);
@@ -403,9 +409,28 @@ export class Globe3D {
           const [x, y] = px(unwrapped[i][0] + shift, unwrapped[i][1]);
           ctx.lineTo(x, y);
         }
+        if (polar) {
+          const last = unwrapped[unwrapped.length - 1];
+          const first = unwrapped[0];
+          const [xL, yP] = px(last[0] + shift, pole);
+          ctx.lineTo(xL, yP);
+          const [xF] = px(first[0] + shift, pole);
+          ctx.lineTo(xF, yP);
+        }
         ctx.closePath();
         ctx.fillStyle = '#0e2640';
         ctx.fill();
+
+        /* Stroke path: coastline only — the bridge to the pole would draw a
+           bright neon line straight through the pole and a vertical edge at
+           ±180°, neither of which is part of the real coast. */
+        ctx.beginPath();
+        ctx.moveTo(x0, y0);
+        for (let i = 1; i < unwrapped.length; i++) {
+          const [x, y] = px(unwrapped[i][0] + shift, unwrapped[i][1]);
+          ctx.lineTo(x, y);
+        }
+        if (!polar) ctx.closePath();
         /* outer glow halo */ ctx.lineWidth = 5;   ctx.strokeStyle = 'rgba(0,185,235,0.25)'; ctx.stroke();
         /* mid glow        */ ctx.lineWidth = 2.5; ctx.strokeStyle = 'rgba(0,210,255,0.60)'; ctx.stroke();
         /* bright core     */ ctx.lineWidth = 1.2; ctx.strokeStyle = 'rgba(155,242,255,1.00)'; ctx.stroke();
@@ -461,14 +486,11 @@ export class Globe3D {
       ctx.restore();
     });
 
-    /* Draw all land rings with neon glow (on top of the Europe violet fill) */
+    /* Draw all land rings with neon glow (on top of the Europe violet fill).
+       Antarctica is now drawn here too — its ring is detected as polar and
+       filled by bridging to the south pole, replacing the old rectangular
+       band + flat lat=-68 stroke that produced a spurious parallel circle. */
     rings.forEach(drawRing);
-
-    /* Antarctica border line */
-    ctx.lineWidth = 2;   ctx.strokeStyle = 'rgba(0,210,255,0.50)';
-    ctx.beginPath(); ctx.moveTo(0, antY); ctx.lineTo(W, antY); ctx.stroke();
-    ctx.lineWidth = 0.9; ctx.strokeStyle = 'rgba(155,242,255,0.95)';
-    ctx.beginPath(); ctx.moveTo(0, antY); ctx.lineTo(W, antY); ctx.stroke();
 
     return new CT(cvs);
   }

--- a/js/globe.js
+++ b/js/globe.js
@@ -362,21 +362,60 @@ export class Globe3D {
     ctx.fillStyle = '#0e2640';
     ctx.fillRect(0, antY, W, H - antY);
 
+    /* Make a ring's longitudes continuous: when consecutive points jump by
+       more than 180° they're really crossing the antimeridian, so unwrap by
+       ±360°. Without this, drawing the ring on the equirectangular texture
+       would stretch the segment across the entire canvas — which then maps
+       to a spurious latitude circle on the sphere (Chukotka, Wrangel, Fiji
+       all do this). */
+    const unwrapRing = (ring) => {
+      if (ring.length === 0) return ring;
+      const out = [[ring[0][0], ring[0][1]]];
+      for (let i = 1; i < ring.length; i++) {
+        let lon = ring[i][0];
+        const prevLon = out[i - 1][0];
+        while (lon - prevLon > 180) lon -= 360;
+        while (lon - prevLon < -180) lon += 360;
+        out.push([lon, ring[i][1]]);
+      }
+      return out;
+    };
+
     /* Draw one ring with a multi-pass neon glow stroke */
     const drawRing = ring => {
-      ctx.beginPath();
-      const [x0, y0] = px(ring[0][0], ring[0][1]);
-      ctx.moveTo(x0, y0);
-      for (let i = 1; i < ring.length; i++) {
-        const [x, y] = px(ring[i][0], ring[i][1]);
-        ctx.lineTo(x, y);
+      /* Antarctica's single ring encloses the south pole, so it can't be
+         flattened cleanly into a 2D rectangle without bridging to lat=-90.
+         The antY band above already covers it — skip the detailed polygon. */
+      if (ring.some(p => p[1] < -65)) return;
+
+      const unwrapped = unwrapRing(ring);
+      let minLon = Infinity, maxLon = -Infinity;
+      for (const p of unwrapped) {
+        if (p[0] < minLon) minLon = p[0];
+        if (p[0] > maxLon) maxLon = p[0];
       }
-      ctx.closePath();
-      ctx.fillStyle = '#0e2640';
-      ctx.fill();
-      /* outer glow halo */ ctx.lineWidth = 5;   ctx.strokeStyle = 'rgba(0,185,235,0.25)'; ctx.stroke();
-      /* mid glow        */ ctx.lineWidth = 2.5; ctx.strokeStyle = 'rgba(0,210,255,0.60)'; ctx.stroke();
-      /* bright core     */ ctx.lineWidth = 1.2; ctx.strokeStyle = 'rgba(155,242,255,1.00)'; ctx.stroke();
+
+      const drawAt = (shift) => {
+        ctx.beginPath();
+        const [x0, y0] = px(unwrapped[0][0] + shift, unwrapped[0][1]);
+        ctx.moveTo(x0, y0);
+        for (let i = 1; i < unwrapped.length; i++) {
+          const [x, y] = px(unwrapped[i][0] + shift, unwrapped[i][1]);
+          ctx.lineTo(x, y);
+        }
+        ctx.closePath();
+        ctx.fillStyle = '#0e2640';
+        ctx.fill();
+        /* outer glow halo */ ctx.lineWidth = 5;   ctx.strokeStyle = 'rgba(0,185,235,0.25)'; ctx.stroke();
+        /* mid glow        */ ctx.lineWidth = 2.5; ctx.strokeStyle = 'rgba(0,210,255,0.60)'; ctx.stroke();
+        /* bright core     */ ctx.lineWidth = 1.2; ctx.strokeStyle = 'rgba(155,242,255,1.00)'; ctx.stroke();
+      };
+
+      drawAt(0);
+      /* If the unwrapped polygon spills past ±180°, redraw shifted so the
+         piece wrapping around to the other hemisphere is rendered as well. */
+      if (maxLon > 180) drawAt(-360);
+      if (minLon < -180) drawAt(360);
     };
 
     /* Paint European land with dark neon violet BEFORE the neon coastlines

--- a/js/globe.js
+++ b/js/globe.js
@@ -452,9 +452,9 @@ export class Globe3D {
     const [clipX0, clipY0] = px(europeMinLon, europeMaxLat);
     const [clipX1, clipY1] = px(europeMaxLon, europeMinLat);
 
-    const overlapsEuropeBounds = (ring) => {
+    const overlapsEuropeBoundsAt = (ring, shift) => {
       for (let i = 0; i < ring.length; i++) {
-        const lon = ring[i][0];
+        const lon = ring[i][0] + shift;
         const lat = ring[i][1];
         if (lon >= europeMinLon && lon <= europeMaxLon && lat >= europeMinLat && lat <= europeMaxLat) {
           return true;
@@ -464,26 +464,44 @@ export class Globe3D {
     };
 
     rings.forEach((ring) => {
-      if (!overlapsEuropeBounds(ring)) return;
-      ctx.save();
-      /* Clip to the Europe rectangle first */
-      ctx.beginPath();
-      ctx.rect(clipX0, clipY0, clipX1 - clipX0, clipY1 - clipY0);
-      ctx.clip();
-      /* Then clip to the land polygon — intersection = land within Europe */
-      ctx.beginPath();
-      const [x0, y0] = px(ring[0][0], ring[0][1]);
-      ctx.moveTo(x0, y0);
-      for (let i = 1; i < ring.length; i++) {
-        const [x, y] = px(ring[i][0], ring[i][1]);
-        ctx.lineTo(x, y);
+      /* Unwrap before clipping. Without this, antimeridian-crossing rings
+         (Russia in particular has European territory) form a self-intersecting
+         path in 2D — the long closing edge cuts through the Europe rect and
+         the nonzero fill rule leaves spurious violet patches (e.g. between
+         Norway and Iceland). Drawing the unwrapped poly at the shift where it
+         actually covers Europe avoids the degenerate geometry. */
+      const unwrapped = unwrapRing(ring);
+      let minLon = Infinity, maxLon = -Infinity;
+      for (const p of unwrapped) {
+        if (p[0] < minLon) minLon = p[0];
+        if (p[0] > maxLon) maxLon = p[0];
       }
-      ctx.closePath();
-      ctx.clip();
-      /* Fill — only visible where both clips overlap (land in Europe) */
-      ctx.fillStyle = '#4e2870';
-      ctx.fillRect(clipX0, clipY0, clipX1 - clipX0, clipY1 - clipY0);
-      ctx.restore();
+
+      const fillAt = (shift) => {
+        ctx.save();
+        /* Clip to the Europe rectangle first */
+        ctx.beginPath();
+        ctx.rect(clipX0, clipY0, clipX1 - clipX0, clipY1 - clipY0);
+        ctx.clip();
+        /* Then clip to the land polygon — intersection = land within Europe */
+        ctx.beginPath();
+        const [x0, y0] = px(unwrapped[0][0] + shift, unwrapped[0][1]);
+        ctx.moveTo(x0, y0);
+        for (let i = 1; i < unwrapped.length; i++) {
+          const [x, y] = px(unwrapped[i][0] + shift, unwrapped[i][1]);
+          ctx.lineTo(x, y);
+        }
+        ctx.closePath();
+        ctx.clip();
+        /* Fill — only visible where both clips overlap (land in Europe) */
+        ctx.fillStyle = '#4e2870';
+        ctx.fillRect(clipX0, clipY0, clipX1 - clipX0, clipY1 - clipY0);
+        ctx.restore();
+      };
+
+      if (overlapsEuropeBoundsAt(unwrapped, 0)) fillAt(0);
+      if (maxLon > 180 && overlapsEuropeBoundsAt(unwrapped, -360)) fillAt(-360);
+      if (minLon < -180 && overlapsEuropeBoundsAt(unwrapped, 360)) fillAt(360);
     });
 
     /* Draw all land rings with neon glow (on top of the Europe violet fill).


### PR DESCRIPTION
## Problema

Sul globo 3D apparivano vari artefatti visivi nella texture dei continenti:

- un paio di cerchi paralleli vicino al polo nord (~+65° e ~+71°)
- una linea poco sotto l'equatore (~−16°)
- una linea continua tutto intorno al globo nell'emisfero sud (~−68°)
- un rettangolo viola tra la Norvegia e l'Islanda (dove non c'è terra)

## Causa

Tutto in `js/globe.js` → `_buildGlobeTexture`, e quasi tutto riconducibile allo stesso bug di base: **anelli che attraversano l'antimeridiano** (±180° di longitudine) venivano disegnati con `lineTo` su una proiezione equirettangolare, producendo geometrie 2D degeneri.

### Anelli problematici nel TopoJSON Natural Earth 110m

| Anello | Punti | Cosa rappresenta | Crossing | Effetto sul globo |
|---|---|---|---|---|
| #7 | 556 | Antartide | 1 (racchiude il polo) | parte del problema, vedi sotto |
| #16 | 11 | Figi | 2 | linea ~−16° |
| #90 | 1321 | Russia / Chukotka | 2 | cerchio ~+65° + rettangolo viola NO/IS |
| #92 | 5 | Isola di Wrangel | 2 | cerchio ~+71° |

### 1. Coastlines: linee orizzontali → cerchi paralleli

Un segmento da `lon +179` a `lon −180` veniva tracciato attraverso tutta la larghezza della texture (2048 px). Sulla sfera diventava un cerchio parallelo neon-cyan luminoso (lo stroke a 3 strati lo rendeva ancora più vistoso).

### 2. Antartide finta rettangolare

L'Antartide non era disegnata come poligono ma come `fillRect(0, antY, W, H−antY)` da lat −68° in giù, con due stroke orizzontali a lat −68° per simularne il bordo. Quella linea retta diventava un quarto cerchio spurio attorno al globo.

### 3. Fill viola dell'Europa: rettangolo fra Norvegia e Islanda

Il blocco che dipinge di viola le terre europee clippava al poligono di ogni `ring` che intersecava il rect Europa. La Russia ha territorio europeo (a ovest degli Urali) quindi l'overlap c'era, ma il poligono Russia **raw** è auto-intersecante in 2D — la linea di chiusura tra l'ultimo punto `(+178.6, 69.4)` e il primo `(-180, 68.96)` taglia orizzontalmente attraverso il rect Europa. Con la regola di riempimento `nonzero` questo lasciava una macchia viola fra Norvegia e Islanda, dove non c'è terra.

## Soluzione

### Commit 1 — `fix(globe)`: split degli anelli all'antimeridiano per le coastlines

- Aggiunta funzione `unwrapRing()` che rende continue le longitudini di un anello: se due punti consecutivi distano più di 180°, "srotola" la coordinata di ±360° così la linea non attraversa più la texture.
- `drawRing` ora chiama l'unwrap e, se l'anello sfora ±180° dopo l'unwrap, ridisegna copie shiftate di ±360° in modo che il pezzo che dovrebbe "wrappare" sull'altro emisfero venga renderizzato sull'estremità opposta del canvas.
- Risolto per Chukotka, Wrangel e Figi.

### Commit 2 — `feat(globe)`: Antartide reale

- Rimossi `fillRect` rettangolare e le 2 stroke orizzontali a lat −68°.
- `drawRing` rileva i ring **polari** (numero dispari di crossing — l'Antartide ha 1 crossing perché il ring racchiude il polo).
- Per i ring polari il **fill path** viene chiuso ponticellando attraverso il polo (lat ±90); lo **stroke path** salta il ponticello in modo che il neon glow segua solo la costa reale.
- L'Antartide è ora visibile con la sua forma vera: penisola Antartica, Mare di Ross, Mare di Weddell visibili.

### Commit 3 — `fix(globe)`: unwrap anche per il fill viola dell'Europa

- Lo stesso pattern `unwrapRing` + redraw shiftato viene applicato al blocco `rings.forEach((ring) => ...)` che dipinge il viola europeo.
- Per i ring non-attraversanti il comportamento è identico a prima; per la Russia il fill viene applicato al pezzo shifted (+360) che effettivamente cade in Europa, senza self-intersection.
- Macchia viola tra Norvegia e Islanda risolta.

## File modificati

- `js/globe.js` — `_buildGlobeTexture()` (3 commits, ~100 righe di diff netto)

Nessuna modifica a dati (`data/world-110m.json` invariato), nessuna nuova dipendenza, nessun cambio API o test.

## Test

- `npm test` → 346/346 ✅
- Verifica logica della texture: gli unwrap dei 4 ring problematici producono span continui senza jump > 180° tra punti consecutivi.
- Screenshot Playwright (Globe3D, WebGL via swiftshader, viewport 1400×1000): vista Europa, Pacifico, Asia, Americhe, polo Nord, polo Sud, e zoom Nord-Europa — tutte pulite, nessun cerchio spurio, Antartide con forma corretta, nessun rettangolo viola fra Norvegia e Islanda.

## Performance

- `unwrapRing` aggiunge un singolo loop O(N) per anello al momento della texture, eseguito **una sola volta** alla creazione del globo. Non a ogni frame.
- Per i ~4 anelli "problematici" servono 1-2 redraw aggiuntivi; per i ~120 anelli "normali" un solo `drawAt(0)`. Impatto trascurabile sul tempo di costruzione, zero impatto runtime.

https://claude.ai/code/session_01JQ8vnctUAJk3aYexQhoBj2