### PR TITLE
Center skills description and stack concurrent CV blocks on mobile

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2287,6 +2287,57 @@ h3 {
   .tl-card-single {
     padding: 1.1rem 1.25rem;
   }
+
+  /* Concurrent blocks: collapse 3-column grid to a single stacked column so
+     career cards and the paired education card don't squeeze side-by-side
+     and double up vertical spine lines. */
+  .tl-concurrent-block {
+    display:  block;
+    position: relative;
+  }
+
+  .tl-concurrent-block > .tl-left,
+  .tl-concurrent-block > .tl-right {
+    display:        block;
+    padding:        0 0 0 2rem;
+    margin-bottom:  1.5rem;
+    text-align:     left;
+    position:       relative;
+  }
+
+  .tl-concurrent-block > .tl-right:last-child {
+    margin-bottom: 0;
+  }
+
+  /* Hide per-pair inner spines — each card gets its own dot via ::before
+     anchored on the main timeline spine. */
+  .tl-concurrent-block > .tl-spine {
+    display: none;
+  }
+
+  .tl-concurrent-block > .tl-left::before,
+  .tl-concurrent-block > .tl-right::before {
+    content:       '';
+    position:      absolute;
+    left:          6px;
+    top:           1.4rem;
+    width:         10px;
+    height:        10px;
+    border-radius: 50%;
+    border:        2px solid var(--bg-alt);
+    transform:     translateX(-50%);
+    z-index:       2;
+  }
+
+  .tl-concurrent-block > .tl-left::before {
+    background: var(--accent);
+    box-shadow: 0 0 8px var(--accent-glow);
+  }
+
+  .tl-concurrent-block > .tl-right::before {
+    background: var(--accent2);
+    box-shadow: 0 0 8px var(--accent2-glow);
+  }
 }
 
 /* ─── 16d. CV page layout ────────────────────────────────── */

--- a/css/styles.css
+++ b/css/styles.css
@@ -1640,6 +1640,10 @@ h3 {
   .section-header--left {
     text-align: center;
   }
+
+  .skills-sticky-desc {
+    margin-inline: auto;
+  }
 }
 
 .skill-group {


### PR DESCRIPTION
## Summary

Two small CSS fixes for mobile layout. Both are scoped inside existing `@media (max-width: 760px)` / `(max-width: 900px)` blocks — desktop is untouched.

### 1. Center the "Expertise" subtitle on mobile (`index.html` skills section)

The `.skills-sticky-desc` paragraph ("Technologies and domains I work with daily.") has `max-width: 26ch`. On mobile the surrounding `.section-header--left` switches to `text-align: center`, but that only centers inline text inside the 26ch block — the block itself stayed left-anchored, so the copy appeared off-center under the centered "Expertise" heading.

**Fix:** add `margin-inline: auto` to `.skills-sticky-desc` inside the `@media (max-width: 900px)` block so the constrained box centers under the heading.

### 2. Stack `.tl-concurrent-block` rows on mobile (CV timeline)

The CV timeline has two row types: regular `.tl-row` and `.tl-concurrent-block` (used when one education entry spans multiple overlapping career entries — e.g. *Technical Manager* + *PhD — Computer Science*). Regular rows already collapse to a single column under 760px, but the concurrent block kept its `grid-template-columns: 1fr auto 1fr`, so those cards stayed squeezed side-by-side and the block's inner spine column rendered alongside the main `.cv-timeline::before` spine — producing the two parallel vertical lines visible on the left edge.

**Fix (mobile only, ≤760px):**
- Collapse `.tl-concurrent-block` to a single stacked column (`display: block`).
- Hide the per-pair inner `.tl-spine` cells.
- Restore one dot per card via `::before` anchored at `left: 6px` (on the main spine line), with the career colour (`var(--accent)`) for `.tl-left` cards and the education colour (`var(--accent2)`) for the `.tl-right` card.

## Test plan

- [x] `npm test` — 346/346 pass locally with deps installed
- [ ] Visually verify on a real phone once Pages picks up the deploy: skills subtitle is centered under "Expertise", and the CV timeline shows the *Technical Manager* / *PhD* entries stacked with a single spine line and one dot per card

---
_Generated by [Claude Code](https://claude.ai/code/session_01LL43zhry4iQeNfmfrZBQKP)_