### PR TITLE
Simplify project image fields: remove thumb, keep only bg

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Quick summary:
    title:       "My Project Title"
    year:        "2024"
    tags:        "AI, CV, Python"
-   thumb:       "img/projects/my-thumb.jpg"
+   bg:          "img/projects/my-bg.jpg"
    description: "Short 2–3 sentence summary shown on the homepage card."
    ---
 
@@ -334,9 +334,8 @@ Prints the generated HTML and the `data/projects.js` entry without writing any f
 | `title`       | string | Yes      | Project title                                        |
 | `year`        | string | Yes      | Year of the project, e.g. `"2024"`                   |
 | `tags`        | string | Yes      | Comma-separated keyword badges, e.g. `"AI, CV"`      |
-| `thumb`       | string | Yes      | Path to 16:9 thumbnail image                         |
+| `bg`          | string | Yes      | Card background + hero image on the detail page      |
 | `description` | string | Yes      | Short summary shown on the homepage and listing card |
-| `bg`          | string | No       | Semi-transparent background image for the card       |
 | `url`         | string | No       | Override the output URL path                         |
 
 ### Supported Markdown syntax

--- a/data/projects.js
+++ b/data/projects.js
@@ -8,7 +8,7 @@
      title:       'My Project Title',         // short title (one line)
      year:        '2024',                     // project year (string)
      tags:        ['AI', 'CV'],               // 1–3 keyword badges
-     thumb:       'img/projects/my-thumb.jpg',// 16:9 thumbnail path
+     bg:          'img/projects/my-bg.jpg',    // card background + hero image
      description: 'Short 2–3 sentence summary shown on the homepage card.',
      url:         'projects.html#my-project', // link to detail section
    }
@@ -23,7 +23,6 @@ export const PROJECTS = [
             title: "MPI for Brain Research: Software for Reptilian Neuroscience",
             year: "2015 – 2017",
             tags: ["Scientific Computing","Neuroscience","Data Analysis"],
-            thumb: "img/projects/mpi-brain-thumb.webp",
             bg: "img/projects/mpi-brain-bg.jpeg",
             description: "Two years as a scientific software developer in Gilles Laurent's department at the Max Planck Institute for Brain Research in Frankfurt, building MATLAB analysis pipelines and R/Shiny web apps for electrophysiologists studying sleep in bearded dragons and visual processing in ex-vivo turtle brains.",
             url: "projects/mpi-brain-research.html",
@@ -33,7 +32,6 @@ export const PROJECTS = [
             title: "TRACTION: Opera Co-creation for Social Transformation",
             year: "2020 – 2022",
             tags: ["Web Application","Co-creation","Social Inclusion"],
-            thumb: "img/projects/traction-thumb.png",
             bg: "img/projects/traction-bg.jpg",
             description: "TRACTION was a Horizon 2020 project, coordinated by Vicomtech, that used opera as a vehicle for social inclusion. My work centred on the Co-creation Stage — the real-time distributed performance tool — spanning development, user-requirements gathering, evaluation, and direct engagement with artistic and community partners across Barcelona, Leiria and Ireland.",
             url: "projects/traction.html",
@@ -43,7 +41,6 @@ export const PROJECTS = [
             title: "ARoundTheWorld: Collaborative AR for Education",
             year: "2024",
             tags: ["AR","Education","User Study"],
-            thumb: "img/projects/ARound_the_world_1.png",
             bg: "img/projects/ARound_the_world_2.png",
             description: "ARoundTheWorld is a multiplatform collaborative AR geography application built on the cleAR architecture. It was evaluated with 44 students across three schools and represents the final paper of my PhD, validating that the architecture can produce applications that integrate seamlessly into existing school curricula.",
             url: "projects/aroundtheworld.html",
@@ -53,7 +50,6 @@ export const PROJECTS = [
             title: "cleAR: Interoperable Architecture for Multi-User AR",
             year: "2023",
             tags: ["AR","Education","Architecture"],
-            thumb: "img/projects/clear-architecture.jpg",
             bg: "img/projects/clear-architecture.jpg",
             description: "cleAR is a modular, interoperable architecture for building multi-user augmented reality applications in education. Designed from the ground up to bridge the gap between AR's potential and its limited classroom adoption, it was the core contribution of my PhD research.",
             url: "projects/clear-architecture.html",
@@ -63,7 +59,6 @@ export const PROJECTS = [
             title: "RAG Document Assistant for Financial Services",
             year: "2023",
             tags: ["RAG","LLM","NLP"],
-            thumb: "img/projects/rag-query.svg",
             bg: "img/projects/rag-query.svg",
             description: "A retrieval-augmented generation system built for a large European bank, replacing manual SharePoint search with a conversational assistant that answers questions and cites the exact document and page where each answer was found.",
             url: "projects/rag-document-qa.html",
@@ -73,7 +68,6 @@ export const PROJECTS = [
             title: "Multi-modal Audience Engagement Measurement System",
             year: "2020",
             tags: ["Computer Vision","Multi-modal Sensing","Live Events"],
-            thumb: "img/projects/audience-engagement-thumb.webp",
             bg: "img/projects/audience-engagement-bg.webp",
             description: "A multi-modal system that measures audience engagement at live events by fusing computer vision with WiFi/Bluetooth signal analysis. Designed, implemented, and validated at Vicomtech in 2020, and released as open-source software.",
             url: "projects/audience-engagement.html",
@@ -83,7 +77,6 @@ export const PROJECTS = [
             title: "UFC Fighter Tracking: Multi-Modal Sensing in the Octagon",
             year: "2017",
             tags: ["Computer Vision","Sensor Fusion","Sports Analytics"],
-            thumb: "img/projects/ufc-octagon-thumb.webp",
             bg: "img/projects/ufc-octagon-bg.webp",
             description: "End-to-end real-time analytics for live UFC events: stereo computer vision in the truss above the octagon, accelerometers in the gloves, GPU inference at the venue, and statistics streamed to fans worldwide. Built at AGT International in 2017 and demoed live by our CEO during Werner Vogels' keynote at AWS re:Invent 2017.",
             url: "projects/ufc-fighter-tracking.html",
@@ -93,7 +86,6 @@ export const PROJECTS = [
             title: "AVATecH: Automated Annotation of Audio/Video Corpora for Humanities Research",
             year: "2009 – 2014",
             tags: ["Computer Vision","Audio Analysis","Digital Humanities"],
-            thumb: "img/projects/avatech-thumb.jpg",
             bg: "img/projects/avatech-bg.jpg",
             description: "AVATecH was a joint Fraunhofer / Max Planck project that brought state-of-the-art audio and video pattern recognition into ELAN — the de-facto annotation tool used by linguists, anthropologists, and psychologists worldwide — turning weeks of manual labelling into minutes of supervised review.",
             url: "projects/avatech.html",

--- a/docs/project-template.md
+++ b/docs/project-template.md
@@ -8,13 +8,11 @@
 #   title:       Project title (quoted string)
 #   year:        Project year (quoted string)
 #   tags:        Comma-separated keywords, 1–3 (quoted string)
-#   thumb:       Path to 16:9 thumbnail (used as card bg if `bg` is omitted)
+#   bg:          Path to image used semi-transparently behind the homepage
+#                card AND as the hero banner on the detail page.
 #   description: Short 2–3 sentence summary shown on the homepage card
 #
 # Optional:
-#   bg:          Path to a background image used semi-transparently behind
-#                the homepage card AND as the hero banner on the detail page.
-#                Falls back to `thumb` when omitted.
 #   link_paper:  "https://link.springer.com/..."
 #   link_github: "https://github.com/..."
 #   link_demo:   "https://..."
@@ -24,7 +22,6 @@ id:          my-project-slug
 title:       "My Project Title"
 year:        "2024"
 tags:        "AI, Computer Vision"
-thumb:       "img/projects/my-thumb.jpg"
 bg:          "img/projects/my-bg.jpg"
 description: "Short 2–3 sentence summary shown on the homepage project card."
 ---

--- a/drafts/aroundtheworld.md
+++ b/drafts/aroundtheworld.md
@@ -3,7 +3,7 @@ id:          aroundtheworld
 title:       "ARoundTheWorld: Collaborative AR for Education"
 year:        "2024"
 tags:        "AR, Education, User Study"
-thumb:       "img/projects/ARound_the_world_1.png"
+bg:       "img/projects/ARound_the_world_1.png"
 bg:          "img/projects/ARound_the_world_2.png"
 description: "ARoundTheWorld is a multiplatform collaborative AR geography application built on the cleAR architecture. It was evaluated with 44 students across three schools and represents the final paper of my PhD, validating that the architecture can produce applications that integrate seamlessly into existing school curricula."
 link_paper:  "https://link.springer.com/article/10.1007/s10055-024-00952-x"

--- a/drafts/audience-engagement.md
+++ b/drafts/audience-engagement.md
@@ -3,7 +3,7 @@ id:          audience-engagement
 title:       "Multi-modal Audience Engagement Measurement System"
 year:        "2020"
 tags:        "Computer Vision, Multi-modal Sensing, Live Events"
-thumb:       "img/projects/audience-engagement-thumb.webp"
+bg:       "img/projects/audience-engagement-thumb.webp"
 bg:          "img/projects/audience-engagement-bg.webp"
 description: "A multi-modal system that measures audience engagement at live events by fusing computer vision with WiFi/Bluetooth signal analysis. Designed, implemented, and validated at Vicomtech in 2020, and released as open-source software."
 link_paper:  "https://link.springer.com/chapter/10.1007/978-3-030-71158-0_17"

--- a/drafts/avatech.md
+++ b/drafts/avatech.md
@@ -3,7 +3,7 @@ id:          avatech
 title:       "AVATecH: Automated Annotation of Audio/Video Corpora for Humanities Research"
 year:        "2009 – 2014"
 tags:        "Computer Vision, Audio Analysis, Digital Humanities"
-thumb:       "img/projects/avatech-thumb.jpg"
+bg:       "img/projects/avatech-thumb.jpg"
 bg:          "img/projects/avatech-bg.jpg"
 description: "AVATecH was a joint Fraunhofer / Max Planck project that brought state-of-the-art audio and video pattern recognition into ELAN — the de-facto annotation tool used by linguists, anthropologists, and psychologists worldwide — turning weeks of manual labelling into minutes of supervised review."
 link_paper:  "https://aclanthology.org/L12-1137/"

--- a/drafts/clear-architecture.md
+++ b/drafts/clear-architecture.md
@@ -3,7 +3,7 @@ id:          clear-architecture
 title:       "cleAR: Interoperable Architecture for Multi-User AR"
 year:        "2023"
 tags:        "AR, Education, Architecture"
-thumb:       "img/projects/clear-architecture.jpg"
+bg:       "img/projects/clear-architecture.jpg"
 bg:          "img/projects/clear-architecture.jpg"
 description: "cleAR is a modular, interoperable architecture for building multi-user augmented reality applications in education. Designed from the ground up to bridge the gap between AR's potential and its limited classroom adoption, it was the core contribution of my PhD research."
 link_paper:  "https://link.springer.com/article/10.1007/s10055-023-00764-5"

--- a/drafts/inevent.md
+++ b/drafts/inevent.md
@@ -3,7 +3,7 @@ id:          inevent
 title:       "inEvent: Structuring and Linking Multimedia Archives of Lectures and Meetings"
 year:        "2011 – 2014"
 tags:        "Computer Vision, Video Analysis, Multimedia"
-thumb:       "img/projects/inevent-thumb.jpg"
+bg:       "img/projects/inevent-thumb.jpg"
 bg:          "img/projects/inevent-bg.jpg"
 description: "An EU FP7 project on indexing, searching and linking large archives of lectures, meetings and video-conferences as interconnected hyper-events. At Fraunhofer HHI I led the video-analysis side of the work — automatic segmentation, slide-transition detection and face-based features for multi-modal speaker linking — published at VISAPP 2014, Interspeech 2014, and the ACM MM 2013 Grand Challenge."
 link_paper:  "https://www.scitepress.org/Papers/2014/46860/"

--- a/drafts/mlops-vertex-media.md
+++ b/drafts/mlops-vertex-media.md
@@ -3,7 +3,7 @@ id:          mlops-vertex-media
 title:       "MLOps Platform on GCP for a Spanish Media Group"
 year:        "2022 – 2023"
 tags:        "MLOps, Vertex AI, GCP"
-thumb:       "img/projects/mlops-thumb.svg"
+bg:       "img/projects/mlops-thumb.svg"
 bg:          "img/projects/mlops-bg.svg"
 description: "End-to-end MLOps platform built on Google Cloud for one of the largest media companies in Spain. Took a portfolio of disconnected ML models: churn prediction, article recommendation and several others, and rebuilt them as Vertex AI pipelines with versioning, monitoring, drift detection and CI/CD across the whole lifecycle."
 ---

--- a/drafts/mpi-brain-research.md
+++ b/drafts/mpi-brain-research.md
@@ -3,7 +3,7 @@ id:          mpi-brain-research
 title:       "MPI for Brain Research: Software for Reptilian Neuroscience"
 year:        "2015 – 2017"
 tags:        "Scientific Computing, Neuroscience, Data Analysis"
-thumb:       "img/projects/mpi-brain-thumb.jpeg"
+bg:       "img/projects/mpi-brain-thumb.jpeg"
 bg:          "img/projects/mpi-brain-bg.jpeg"
 description: "Two years as a scientific software developer in Gilles Laurent's department at the Max Planck Institute for Brain Research in Frankfurt, building MATLAB analysis pipelines and R/Shiny web apps for electrophysiologists studying sleep in bearded dragons and visual processing in ex-vivo turtle brains."
 link_paper:  "https://www.science.org/doi/10.1126/science.aaf3621"

--- a/drafts/rag-document-qa.md
+++ b/drafts/rag-document-qa.md
@@ -3,7 +3,7 @@ id:          rag-document-qa
 title:       "RAG Document Assistant for Financial Services"
 year:        "2023"
 tags:        "RAG, LLM, NLP"
-thumb:       "img/projects/rag-query.svg"
+bg:       "img/projects/rag-query.svg"
 bg:          "img/projects/rag-query.svg"
 description: "A retrieval-augmented generation system built for a large European bank, replacing manual SharePoint search with a conversational assistant that answers questions and cites the exact document and page where each answer was found."
 ---

--- a/drafts/traction.md
+++ b/drafts/traction.md
@@ -3,7 +3,7 @@ id:          traction
 title:       "TRACTION: Opera Co-creation for Social Transformation"
 year:        "2020 – 2022"
 tags:        "Web Application, Co-creation, Social Inclusion"
-thumb:       "img/projects/traction-thumb.png"
+bg:       "img/projects/traction-thumb.png"
 bg:          "img/projects/traction-bg.jpg"
 description: "TRACTION was a Horizon 2020 project, coordinated by Vicomtech, that used opera as a vehicle for social inclusion. My work centred on the Co-creation Stage — the real-time distributed performance tool — spanning development, user-requirements gathering, evaluation, and direct engagement with artistic and community partners across Barcelona, Leiria and Ireland."
 link_demo:    "https://www.traction-project.eu/"

--- a/drafts/ufc-fighter-tracking.md
+++ b/drafts/ufc-fighter-tracking.md
@@ -3,7 +3,7 @@ id:          ufc-fighter-tracking
 title:       "UFC Fighter Tracking: Multi-Modal Sensing in the Octagon"
 year:        "2017"
 tags:        "Computer Vision, Sensor Fusion, Sports Analytics"
-thumb:       "img/projects/ufc-octagon-thumb.webp"
+bg:       "img/projects/ufc-octagon-thumb.webp"
 bg:          "img/projects/ufc-octagon-bg.webp"
 description: "End-to-end real-time analytics for live UFC events: stereo computer vision in the truss above the octagon, accelerometers in the gloves, GPU inference at the venue, and statistics streamed to fans worldwide. Built at AGT International in 2017 and demoed live by our CEO during Werner Vogels' keynote at AWS re:Invent 2017."
 link_video:  "https://www.youtube.com/watch?v=vataVq9gY_o"

--- a/js/main.js
+++ b/js/main.js
@@ -796,7 +796,7 @@ function renderProjectCard(project, i) {
   const tagsHtml = (project.tags || [])
     .map(function(t) { return '<span class="project-tag">' + escapeHtml(t) + '</span>'; })
     .join('');
-  const bgSrc = project.bg || project.thumb || '';
+  const bgSrc = project.bg || '';
   const hasBg = Boolean(bgSrc);
   const style = hasBg
     ? ' style="--card-bg: url(\'' + escapeHtml(bgSrc) + '\')"'

--- a/scripts/new-project.js
+++ b/scripts/new-project.js
@@ -22,13 +22,11 @@
  *   title:       "My Project Title"
  *   year:        "2024"
  *   tags:        "AI, CV, Unity"         # comma-separated
- *   thumb:       "img/projects/my.jpg"   # card thumbnail
+ *   bg:          "img/projects/my-bg.jpg"   # card bg + project-page hero
  *   description: "Short 2–3 sentence summary for the homepage card."
  *   ---
  *
  * Optional frontmatter:
- *   bg:          "img/projects/my-bg.jpg"   # semi-transparent card bg /
- *                                            # project-page hero image
  *   link_paper:  "https://..."
  *   link_github: "https://..."
  *   link_demo:   "https://..."
@@ -76,9 +74,8 @@ Frontmatter fields (YAML between --- delimiters):
   title        (required)  Project title
   year         (required)  Project year
   tags         (required)  Comma-separated tag keywords
-  thumb        (required)  Path to card thumbnail image
+  bg           (required)  Card background + project detail hero image
   description  (required)  Short summary for the homepage card
-  bg                       Semi-transparent card bg + detail hero image
   link_paper              URL to paper (optional)
   link_github             URL to GitHub repo (optional)
   link_demo               URL to live demo (optional)
@@ -123,7 +120,7 @@ function parseFrontmatter(text) {
 }
 
 function validateProjectFrontmatter(fm, filePath) {
-  const required = ['id', 'title', 'year', 'tags', 'thumb', 'description'];
+  const required = ['id', 'title', 'year', 'tags', 'bg', 'description'];
   for (const field of required) {
     if (fm[field] === undefined || fm[field] === '') {
       throw new Error(`Missing required frontmatter field "${field}" in ${filePath}`);
@@ -285,7 +282,7 @@ function deriveOutputPath(id, outDir = 'projects') {
 
 function buildProjectPage(fm, bodyHtml) {
   const tags = parseTags(fm.tags);
-  const heroImg = fm.bg || fm.thumb;
+  const heroImg = fm.bg;
   const tagsHtml = tags
     .map(t => `        <span class="project-tag">${escapeHtml(t)}</span>`)
     .join('\n');
@@ -425,9 +422,8 @@ function updateProjectsJs(projectsJsPath, entry, src) {
     `        title: ${JSON.stringify(entry.title)},`,
     `        year: ${JSON.stringify(entry.year)},`,
     `        tags: ${tagsStr},`,
-    `        thumb: ${JSON.stringify(entry.thumb)},`,
+    `        bg: ${JSON.stringify(entry.bg)},`,
   ];
-  if (entry.bg) lines.push(`        bg: ${JSON.stringify(entry.bg)},`);
   lines.push(`        description: ${JSON.stringify(entry.description)},`);
   lines.push(`        url: ${JSON.stringify(entry.url)},`);
   lines.push('    }');
@@ -470,11 +466,10 @@ function main() {
     title: String(fm.title),
     year: String(fm.year),
     tags: tags,
-    thumb: String(fm.thumb),
+    bg: String(fm.bg),
     description: String(fm.description),
     url: `${opts.outDir.replace(/\\/g, '/')}/${fm.id}.html`,
   };
-  if (fm.bg) projectEntry.bg = String(fm.bg);
 
   if (opts.dryRun) {
     console.log('=== Generated project page HTML ===');

--- a/test/new-project.test.js
+++ b/test/new-project.test.js
@@ -74,24 +74,24 @@ test('project: validateProjectFrontmatter passes with all required fields', () =
     title: 'My Project',
     year: '2024',
     tags: 'AR, CV',
-    thumb: 'img/projects/my-thumb.jpg',
+    bg: 'img/projects/my-bg.jpg',
     description: 'A test project.',
   };
   validateProjectFrontmatter(fm, 'test.md');
 });
 
 test('project: validateProjectFrontmatter throws on missing id', () => {
-  const fm = { title: 'X', year: '2024', tags: 'A', thumb: 'x.jpg', description: 'D' };
+  const fm = { title: 'X', year: '2024', tags: 'A', bg: 'x.jpg', description: 'D' };
   assert.throws(() => validateProjectFrontmatter(fm, 'test.md'), /id/);
 });
 
-test('project: validateProjectFrontmatter throws on missing thumb', () => {
+test('project: validateProjectFrontmatter throws on missing bg', () => {
   const fm = { id: 'x', title: 'X', year: '2024', tags: 'A', description: 'D' };
-  assert.throws(() => validateProjectFrontmatter(fm, 'test.md'), /thumb/);
+  assert.throws(() => validateProjectFrontmatter(fm, 'test.md'), /bg/);
 });
 
 test('project: validateProjectFrontmatter throws on missing description', () => {
-  const fm = { id: 'x', title: 'X', year: '2024', tags: 'A', thumb: 'x.jpg' };
+  const fm = { id: 'x', title: 'X', year: '2024', tags: 'A', bg: 'x.jpg' };
   assert.throws(() => validateProjectFrontmatter(fm, 'test.md'), /description/);
 });
 
@@ -149,7 +149,7 @@ test('project: buildProjectPage produces a full HTML document', () => {
     title: 'Test Project',
     year: '2024',
     tags: 'AI, CV',
-    thumb: 'img/projects/test.jpg',
+    bg: 'img/projects/test.jpg',
     description: 'A short description.',
   };
   const html = buildProjectPage(fm, '<p>Full body.</p>');
@@ -165,7 +165,7 @@ test('project: buildProjectPage uses correct asset paths for project subdir', ()
   // path /js/main.js (Vite resolves the same path on every page).
   const fm = {
     id: 'x', title: 'X', year: '2024', tags: 'A',
-    thumb: 'img/projects/x.jpg', description: 'D',
+    bg: 'img/projects/x.jpg', description: 'D',
   };
   const html = buildProjectPage(fm, '<p>body</p>');
   assert.match(html, /href="\.\.\/css\/styles\.css"/);
@@ -176,7 +176,7 @@ test('project: buildProjectPage uses correct asset paths for project subdir', ()
 test('project: buildProjectPage includes title, year, tags, and body', () => {
   const fm = {
     id: 'y', title: 'Cool Project', year: '2023', tags: 'AR, Unity',
-    thumb: 'img/projects/y.jpg', description: 'Description.',
+    bg: 'img/projects/y.jpg', description: 'Description.',
   };
   const html = buildProjectPage(fm, '<p>Inner body.</p>');
   assert.match(html, /Cool Project/);
@@ -189,7 +189,6 @@ test('project: buildProjectPage includes title, year, tags, and body', () => {
 test('project: buildProjectPage renders bg as hero banner when provided', () => {
   const fm = {
     id: 'z', title: 'Z', year: '2024', tags: 'A',
-    thumb: 'img/projects/z.jpg',
     bg: 'img/projects/z-bg.jpg',
     description: 'D',
   };
@@ -199,21 +198,10 @@ test('project: buildProjectPage renders bg as hero banner when provided', () => 
   assert.match(html, /project-hero/);
 });
 
-test('project: buildProjectPage falls back to thumb when bg is not set', () => {
-  const fm = {
-    id: 'w', title: 'W', year: '2024', tags: 'A',
-    thumb: 'img/projects/w.jpg',
-    description: 'D',
-  };
-  const html = buildProjectPage(fm, '<p>b</p>');
-  // No bg → hero uses the thumb
-  assert.match(html, /img\/projects\/w\.jpg/);
-});
-
 test('project: buildProjectPage includes optional link_paper', () => {
   const fm = {
     id: 'x', title: 'X', year: '2024', tags: 'A',
-    thumb: 'x.jpg', description: 'D',
+    bg: 'x.jpg', description: 'D',
     link_paper: 'https://example.com/paper',
   };
   const html = buildProjectPage(fm, '<p>Body</p>');
@@ -224,7 +212,7 @@ test('project: buildProjectPage includes optional link_paper', () => {
 test('project: buildProjectPage includes optional link_github', () => {
   const fm = {
     id: 'x', title: 'X', year: '2024', tags: 'A',
-    thumb: 'x.jpg', description: 'D',
+    bg: 'x.jpg', description: 'D',
     link_github: 'https://github.com/user/repo',
   };
   const html = buildProjectPage(fm, '<p>Body</p>');
@@ -235,7 +223,7 @@ test('project: buildProjectPage includes optional link_github', () => {
 test('project: buildProjectPage includes a back-to-projects link', () => {
   const fm = {
     id: 'x', title: 'X', year: '2024', tags: 'A',
-    thumb: 'x.jpg', description: 'D',
+    bg: 'x.jpg', description: 'D',
   };
   const html = buildProjectPage(fm, '<p>Body</p>');
   // Relative link back to projects listing
@@ -245,7 +233,7 @@ test('project: buildProjectPage includes a back-to-projects link', () => {
 test('project: buildProjectPage escapes HTML in tags/title', () => {
   const fm = {
     id: 'x', title: 'A & B <script>', year: '2024', tags: 'Tag<x>',
-    thumb: 'x.jpg', description: 'D',
+    bg: 'x.jpg', description: 'D',
   };
   const html = buildProjectPage(fm, '<p>body</p>');
   assert.ok(!html.includes('<script>A'), 'Title should be escaped');
@@ -261,7 +249,6 @@ test('project: updateProjectsJs prepends entry to empty PROJECTS array', () => {
     title: 'New Project',
     year: '2024',
     tags: ['AI', 'CV'],
-    thumb: 'img/projects/new.jpg',
     bg: 'img/projects/new-bg.jpg',
     description: 'A new project.',
     url: 'projects/new-proj.html',
@@ -274,21 +261,6 @@ test('project: updateProjectsJs prepends entry to empty PROJECTS array', () => {
   assert.match(result, /bg:/);
 });
 
-test('project: updateProjectsJs omits bg key when not provided', () => {
-  const src = `const PROJECTS = [];\n`;
-  const entry = {
-    id: 'new-proj',
-    title: 'New Project',
-    year: '2024',
-    tags: ['AI'],
-    thumb: 'img/projects/new.jpg',
-    description: 'A new project.',
-    url: 'projects/new-proj.html',
-  };
-  const result = updateProjectsJs('data/projects.js', entry, src);
-  assert.ok(!/bg:/.test(result), 'bg should not appear when undefined');
-});
-
 test('project: updateProjectsJs entry url points to projects/<slug>.html', () => {
   const src = `const PROJECTS = [];\n`;
   const entry = {
@@ -296,7 +268,7 @@ test('project: updateProjectsJs entry url points to projects/<slug>.html', () =>
     title: 'T',
     year: '2024',
     tags: ['AI'],
-    thumb: 't.jpg',
+    bg: 't.jpg',
     description: 'D',
     url: 'projects/slug-x.html',
   };
@@ -316,7 +288,7 @@ test('project: updateProjectsJs prepends entry before existing entries', () => {
     title: 'New Project',
     year: '2024',
     tags: ['AI'],
-    thumb: 'img/projects/new.jpg',
+    bg: 'img/projects/new.jpg',
     description: 'A new project.',
     url: 'projects/new-proj.html',
   };
@@ -328,7 +300,7 @@ test('project: updateProjectsJs prepends entry before existing entries', () => {
 
 test('project: updateProjectsJs throws when PROJECTS array not found', () => {
   const src = 'const SOMETHING_ELSE = [];';
-  const entry = { id: 'x', title: 'X', year: '2024', tags: [], thumb: '', description: '', url: '' };
+  const entry = { id: 'x', title: 'X', year: '2024', tags: [], bg: '', description: '', url: '' };
   assert.throws(() => updateProjectsJs('data/projects.js', entry, src), /PROJECTS/);
 });
 
@@ -339,7 +311,7 @@ test('project: updateProjectsJs accepts ES module export form', () => {
     title: 'ESM Project',
     year: '2024',
     tags: ['ESM'],
-    thumb: 'img/projects/esm.jpg',
+    bg: 'img/projects/esm.jpg',
     description: 'ES module form.',
     url: 'projects/esm-proj.html',
   };
@@ -356,7 +328,6 @@ id: e2e-test
 title: "End-to-End Test Project"
 year: "2024"
 tags: "AI, Testing"
-thumb: "img/projects/e2e.jpg"
 bg:    "img/projects/e2e-bg.jpg"
 description: "An end-to-end test project."
 link_github: "https://github.com/test/repo"


### PR DESCRIPTION
## Summary

- Il campo `thumb` era ridondante: veniva usato solo come fallback quando `bg` era assente, ma in pratica tutti gli 8 progetti avevano già `bg` impostato
- Unificato a un singolo campo `bg` che copre sia lo sfondo della card che l'hero della pagina di dettaglio
- Rimosso il codice di fallback `|| project.thumb` in `renderProjectCard`

## Modifiche

- `data/projects.js` — rimosso `thumb` da tutti gli 8 progetti
- `js/main.js` — rimosso il fallback `|| project.thumb` in `renderProjectCard`
- `scripts/new-project.js` — `bg` è ora obbligatorio; rimosso `thumb` da validazione, serializzazione entry e costruzione oggetto in `main()`
- `test/new-project.test.js` — aggiornati tutti i fixture; rimossi test obsoleti (fallback thumb, bg condizionale)
- `docs/project-template.md`, `README.md` — documentazione aggiornata
- `drafts/*.md` — rinominato `thumb:` → `bg:` in tutti i 10 draft

## Test plan

- [x] `npm run test:project` — 32/32 test passati
- [x] `npm test` — 253/255 passati (i 2 falliti sono pre-esistenti: dipendenza `three` non installata nell'ambiente CI)

https://claude.ai/code/session_01XtjTYABrBgGdjMkvx52U4M

---
_Generated by [Claude Code](https://claude.ai/code/session_01XtjTYABrBgGdjMkvx52U4M)_