### PR TITLE
Pre-launch polish: accessibility, SEO, Three.js lazy-load, bug fixes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,15 +3,6 @@
 Outstanding items. Completed work and accepted trade-offs have been removed —
 see git history if you need the audit context.
 
-## Accessibility
-
-- **Globe canvas is not keyboard-navigable.** Interactive pins on the 3-D
-  globe can't be reached with Tab. Consider exposing the same data as a
-  visually-hidden description list so screen-reader / keyboard users can still
-  read the locations.
-- **Verify side-dot nav `aria-label`s.** Confirm the JS sets `aria-label` on
-  each dot (not just `data-label`) so screen readers announce the section name.
-
 ## Code structure
 
 - **Continue extracting from `js/main.js`.** It is ~1450 lines and still owns

--- a/css/styles.css
+++ b/css/styles.css
@@ -59,7 +59,7 @@
   --text: #e8eee5;
   --text-rgb: 232 238 229;
   --text-muted: #8a948b;
-  --text-faint: #5e6862;
+  --text-faint: #767f78;
 
   --hero-grad-from: #e6d4a4;
   --hero-grad-to: #6db088;

--- a/cv.html
+++ b/cv.html
@@ -8,7 +8,7 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://nominatim.openstreetmap.org; media-src 'self'; worker-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; manifest-src 'self'; upgrade-insecure-requests" />
   <!-- /generated:csp-meta -->
   <meta name="description"
-    content="Curriculum Vitae of Stefano Masneri — Senior AI Engineer. Work experience and education." />
+    content="Curriculum Vitae of Stefano Masneri, Senior AI Engineer — 15+ years in machine learning, computer vision, AR and generative AI, with a PhD and 30+ publications." />
   <meta name="author" content="Stefano Masneri" />
   <meta name="robots" content="index, follow, noai, noimageai" />
   <title>CV — Stefano Masneri, Senior AI Engineer</title>
@@ -21,7 +21,7 @@
     "@type": "ProfilePage",
     "url": "https://stefanomasneri.com/cv.html",
     "name": "CV — Stefano Masneri, Senior AI Engineer",
-    "description": "Curriculum Vitae of Stefano Masneri — Senior AI Engineer. Work experience and education.",
+    "description": "Curriculum Vitae of Stefano Masneri, Senior AI Engineer — 15+ years in machine learning, computer vision, AR and generative AI, with a PhD and 30+ publications.",
     "mainEntity": {
       "@type": "Person",
       "name": "Stefano Masneri",

--- a/data/palettes.yaml
+++ b/data/palettes.yaml
@@ -28,7 +28,7 @@ palettes:
     # ── Text tiers ──
     text: '#e8eee5'
     textMuted: '#8a948b'
-    textFaint: '#5e6862'
+    textFaint: '#767f78'
     # ── Accents ──
     accent: '#c8a44d'
     accentHi: '#dcb968'
@@ -84,7 +84,7 @@ palettes:
     # ── Text tiers ──
     text: '#f4ebe1'
     textMuted: '#a39588'
-    textFaint: '#7a6f64'
+    textFaint: '#847868'
     # ── Accents ──
     accent: '#f4a261'
     accentHi: '#f7b67f'
@@ -140,7 +140,7 @@ palettes:
     # ── Text tiers ──
     text: '#f0e6e3'
     textMuted: '#a3908c'
-    textFaint: '#6e5d5a'
+    textFaint: '#8a7b78'
     # ── Accents ──
     accent: '#d64550'
     accentHi: '#e86a64'

--- a/index.html
+++ b/index.html
@@ -13,20 +13,20 @@
   <meta name="keywords" content="Stefano Masneri, AI Engineer, Machine Learning, Computer Vision, Augmented Reality, Deep Learning, XR, ViT, Speaker Diarisation, San Sebastián" />
   <!-- Disallow AI/LLM training use of this page's content -->
   <meta name="robots" content="index, follow, noai, noimageai" />
-  <title>Stefano Masneri — ML, Vision &amp; AR</title>
+  <title>Stefano Masneri — Machine Learning, Computer Vision &amp; AR</title>
   <link rel="canonical" href="https://stefanomasneri.com/" />
 
   <!-- Open Graph / Twitter Card -->
   <meta property="og:type"        content="website" />
   <meta property="og:url"         content="https://stefanomasneri.com/" />
-  <meta property="og:title"       content="Stefano Masneri — ML, Vision &amp; AR" />
+  <meta property="og:title"       content="Stefano Masneri — Machine Learning, Computer Vision &amp; AR" />
   <meta property="og:description" content="Senior AI Engineer specialising in Machine Learning, Computer Vision, and Augmented Reality. Based in San Sebastián, Spain." />
   <meta property="og:image"       content="https://stefanomasneri.com/img/screenshot-hero.png" />
   <meta property="og:image:alt"   content="Stefano Masneri personal website hero section" />
   <meta property="og:locale"      content="en_GB" />
   <meta property="og:site_name"   content="Stefano Masneri" />
   <meta name="twitter:card"        content="summary_large_image" />
-  <meta name="twitter:title"       content="Stefano Masneri — ML, Vision &amp; AR" />
+  <meta name="twitter:title"       content="Stefano Masneri — Machine Learning, Computer Vision &amp; AR" />
   <meta name="twitter:description" content="Senior AI Engineer specialising in Machine Learning, Computer Vision, and Augmented Reality. Based in San Sebastián, Spain." />
   <meta name="twitter:image"       content="https://stefanomasneri.com/img/screenshot-hero.png" />
   <meta name="twitter:image:alt"   content="Stefano Masneri personal website" />

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://nominatim.openstreetmap.org; media-src 'self'; worker-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; manifest-src 'self'; upgrade-insecure-requests" />
   <!-- /generated:csp-meta -->
   <meta name="description"
-    content="Stefano Masneri — Senior AI Lead specialising in Machine Learning, Computer Vision, and Augmented Reality. Based in San Sebastián, Spain." />
+    content="Stefano Masneri — Senior AI Engineer specialising in Machine Learning, Computer Vision, and Augmented Reality. Based in San Sebastián, Spain." />
   <meta name="author" content="Stefano Masneri" />
   <meta name="keywords" content="Stefano Masneri, AI Engineer, Machine Learning, Computer Vision, Augmented Reality, Deep Learning, XR, ViT, Speaker Diarisation, San Sebastián" />
   <!-- Disallow AI/LLM training use of this page's content -->
@@ -20,14 +20,14 @@
   <meta property="og:type"        content="website" />
   <meta property="og:url"         content="https://stefanomasneri.com/" />
   <meta property="og:title"       content="Stefano Masneri — ML, Vision &amp; AR" />
-  <meta property="og:description" content="Senior AI Lead specialising in Machine Learning, Computer Vision, and Augmented Reality. Based in San Sebastián, Spain." />
+  <meta property="og:description" content="Senior AI Engineer specialising in Machine Learning, Computer Vision, and Augmented Reality. Based in San Sebastián, Spain." />
   <meta property="og:image"       content="https://stefanomasneri.com/img/screenshot-hero.png" />
   <meta property="og:image:alt"   content="Stefano Masneri personal website hero section" />
   <meta property="og:locale"      content="en_GB" />
   <meta property="og:site_name"   content="Stefano Masneri" />
   <meta name="twitter:card"        content="summary_large_image" />
   <meta name="twitter:title"       content="Stefano Masneri — ML, Vision &amp; AR" />
-  <meta name="twitter:description" content="Senior AI Lead specialising in Machine Learning, Computer Vision, and Augmented Reality. Based in San Sebastián, Spain." />
+  <meta name="twitter:description" content="Senior AI Engineer specialising in Machine Learning, Computer Vision, and Augmented Reality. Based in San Sebastián, Spain." />
   <meta name="twitter:image"       content="https://stefanomasneri.com/img/screenshot-hero.png" />
   <meta name="twitter:image:alt"   content="Stefano Masneri personal website" />
 
@@ -78,10 +78,6 @@
   <!-- Theme colour for browser chrome (Android, Safari PWA) -->
   <meta name="theme-color" content="#0a120e" />
 
-  <!-- Resource hints — pre-warm connections before the browser needs them -->
-  <link rel="preconnect" href="https://cdnjs.cloudflare.com" />
-  <!-- dns-prefetch: fallback for browsers that do not support preconnect -->
-  <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com" />
   <!-- Self-hosted fonts (no external requests to Google) -->
   <!-- Preload the two weights used above the fold so text doesn't re-flow when
        fonts arrive (Inter 400 for body, Outfit 700 for hero/display). -->
@@ -290,9 +286,9 @@
       <button class="research-scroll-btn research-scroll-btn--right" id="research-scroll-right" aria-label="Scroll research cards right">
         <svg viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M9 5l7 7-7 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
-      <div class="research-grid" id="research-grid" role="list">
+      <div class="research-grid" id="research-grid">
 
-        <div class="research-card" role="listitem" data-animate data-delay="0">
+        <div class="research-card" data-animate data-delay="0">
           <div class="card-inner">
             <div class="card-front">
               <span class="card-icon" aria-hidden="true">
@@ -316,7 +312,7 @@
           </div>
         </div>
 
-        <div class="research-card" role="listitem" data-animate data-delay="80">
+        <div class="research-card" data-animate data-delay="80">
           <div class="card-inner">
             <div class="card-front">
               <span class="card-icon" aria-hidden="true">
@@ -339,7 +335,7 @@
           </div>
         </div>
 
-        <div class="research-card" role="listitem" data-animate data-delay="160">
+        <div class="research-card" data-animate data-delay="160">
           <div class="card-inner">
             <div class="card-front">
               <span class="card-icon" aria-hidden="true">
@@ -363,7 +359,7 @@
           </div>
         </div>
 
-        <div class="research-card" role="listitem" data-animate data-delay="240">
+        <div class="research-card" data-animate data-delay="240">
           <div class="card-inner">
             <div class="card-front">
               <span class="card-icon" aria-hidden="true">
@@ -386,7 +382,7 @@
           </div>
         </div>
 
-        <div class="research-card" role="listitem" data-animate data-delay="320">
+        <div class="research-card" data-animate data-delay="320">
           <div class="card-inner">
             <div class="card-front">
               <span class="card-icon" aria-hidden="true">
@@ -408,7 +404,7 @@
           </div>
         </div>
 
-        <div class="research-card" role="listitem" data-animate data-delay="400">
+        <div class="research-card" data-animate data-delay="400">
           <div class="card-inner">
             <div class="card-front">
               <span class="card-icon" aria-hidden="true">
@@ -565,7 +561,7 @@
       <div class="about-maps" data-animate data-delay="300">
         <div class="globe-header">
           <span class="section-tag">Places</span>
-          <h3 class="globe-title">Where I've Been</h3>
+          <h2 class="globe-title">Where I've Been</h2>
           <p class="globe-intro">
             Travelling is one of my greatest passions — I've been lucky enough to explore many countries
             around the world, both on work assignments and personal adventures.
@@ -599,7 +595,9 @@
           <!-- 2D Europe Map -->
           <div class="maps-col maps-col--europe">
             <div class="europe-scene">
-              <canvas id="europe-canvas" aria-label="2D map of Europe showing location details"></canvas>
+              <!-- Decorative twin of the 3D globe; the globe already exposes
+                   a screen-reader list (#globe-a11y-list), so hide this from AT. -->
+              <canvas id="europe-canvas" aria-hidden="true"></canvas>
               <div class="europe-tooltip" id="europe-tooltip" aria-live="polite">
                 <span class="et-type"></span>
                 <strong class="et-name"></strong>

--- a/js/animations.js
+++ b/js/animations.js
@@ -108,12 +108,31 @@ export function initCardTilt() {
 export function initCardFlip() {
   if (typeof document === 'undefined') return;
   document.querySelectorAll('#research-grid .research-card').forEach((card) => {
-    card.addEventListener('click', () => {
+    /* Expose the click-to-flip as a keyboard-operable control so keyboard and
+       screen-reader users can reach the back face (which holds links found
+       nowhere else). The back face is visibility:hidden until flipped, so its
+       links only enter the tab order once the card is expanded. */
+    const title = card.querySelector('.card-title')?.textContent?.trim();
+    card.setAttribute('role', 'button');
+    card.setAttribute('tabindex', '0');
+    card.setAttribute('aria-expanded', 'false');
+    if (title) card.setAttribute('aria-label', `${title} — show details`);
+
+    const toggle = () => {
       const flipping = card.classList.toggle('is-flipped');
+      card.setAttribute('aria-expanded', flipping ? 'true' : 'false');
       /* Reset tilt state so the card springs back to neutral when flipped */
       if (flipping) {
         card.style.transform = '';
         card.style.transition = '';
+      }
+    };
+
+    card.addEventListener('click', toggle);
+    card.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+        e.preventDefault();
+        toggle();
       }
     });
   });

--- a/js/europe-map.js
+++ b/js/europe-map.js
@@ -5,7 +5,6 @@
    Uses Canvas2D rendering with neon aesthetic matching the 3D globe
    ============================================================ */
 
-/* eslint-disable */
 import { THEME, rgba } from './theme.js';
 
 export class EuropeMap2D {
@@ -36,6 +35,9 @@ export class EuropeMap2D {
     this._rect = null;
     this._rafId = null;
     this._visible = true;
+    /* Track every listener + observer so destroy() can tear them all down. */
+    this._listeners = [];
+    this._io = null;
 
     /* Performance: cache tooltip refs */
     this._ttType = this.tooltip?.querySelector('.et-type') || null;
@@ -61,13 +63,13 @@ export class EuropeMap2D {
     this._loadTopoJSON();
 
     /* Pause when canvas is out of viewport */
-    const _ioEurope = new IntersectionObserver(([e]) => {
+    this._io = new IntersectionObserver(([e]) => {
       this._visible = e.isIntersecting;
       if (this._visible && !this._rafId) this._animate();
     }, { threshold: 0 });
-    _ioEurope.observe(canvasEl);
+    this._io.observe(canvasEl);
 
-    document.addEventListener('visibilitychange', () => {
+    this._addListener(document, 'visibilitychange', () => {
       if (!document.hidden && !this._rafId) this._animate();
     });
 
@@ -182,7 +184,7 @@ export class EuropeMap2D {
   _bindEvents() {
     if (typeof this.canvas.addEventListener !== 'function') return;
 
-    this.canvas.addEventListener('mousemove', (e) => {
+    this._addListener(this.canvas, 'mousemove', (e) => {
       this._rect = this.canvas.getBoundingClientRect();
       /* Scale from CSS pixels to canvas bitmap pixels */
       const scaleX = this.canvas.width / this._rect.width;
@@ -197,17 +199,24 @@ export class EuropeMap2D {
       this._ensureAnimating();
     }, false);
 
-    this.canvas.addEventListener('mouseleave', () => {
+    this._addListener(this.canvas, 'mouseleave', () => {
       this._mouseOver = false;
       this._hideTooltip();
     }, false);
 
-    window.addEventListener('resize', () => {
+    this._addListener(window, 'resize', () => {
       this._resize();
       this._buildFilteredPins();
       this._buildFilteredTrips();
       this._rect = null;
     }, false);
+  }
+
+  /* Track + register a listener so destroy() can later remove it. */
+  _addListener(target, type, fn, opts) {
+    if (!target || typeof target.addEventListener !== 'function') return;
+    target.addEventListener(type, fn, opts);
+    this._listeners.push({ target, type, fn, opts });
   }
 
   _rayhit() {
@@ -601,6 +610,11 @@ export class EuropeMap2D {
   destroy() {
     if (this._rafId) cancelAnimationFrame(this._rafId);
     this._rafId = null;
+    if (this._io) { this._io.disconnect(); this._io = null; }
+    for (const { target, type, fn, opts } of (this._listeners || [])) {
+      try { target.removeEventListener(type, fn, opts); } catch (_) { /* ignore */ }
+    }
+    this._listeners = [];
   }
 }
 

--- a/js/globe.js
+++ b/js/globe.js
@@ -73,6 +73,7 @@ export async function geocodeLocations(locs) {
     try {
       const url = `${API}?q=${encodeURIComponent(item.name)}&format=json&limit=1`;
       const res = await fetch(url);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const json = await res.json();
       if (!json.length) throw new Error('no results');
       item.lat = parseFloat(json[0].lat);
@@ -1043,6 +1044,9 @@ export class GlobeFallback2D {
     if (!this.ctx) return;
     this._visible = true;
     this._rafId = null;
+    /* Track every listener + observer so destroy() can tear them all down. */
+    this._listeners = [];
+    this._io = null;
     this._isLowPower = isLowPowerDevice();
     this._rot = -1.55;
     this._spin = this._isLowPower ? 0.001 : 0.0016;
@@ -1058,15 +1062,22 @@ export class GlobeFallback2D {
     this._bindEvents();
     this._animate();
 
-    const io = new IntersectionObserver(([entry]) => {
+    this._io = new IntersectionObserver(([entry]) => {
       this._visible = entry.isIntersecting;
       if (this._visible && !this._rafId) this._animate();
     }, { threshold: 0 });
-    io.observe(canvasEl);
+    this._io.observe(canvasEl);
 
-    document.addEventListener('visibilitychange', () => {
+    this._addListener(document, 'visibilitychange', () => {
       if (!document.hidden && !this._rafId) this._animate();
     });
+  }
+
+  /* Track + register a listener so destroy() can later remove it. */
+  _addListener(target, type, fn, opts) {
+    if (!target || typeof target.addEventListener !== 'function') return;
+    target.addEventListener(type, fn, opts);
+    this._listeners.push({ target, type, fn, opts });
   }
 
   _collectPoints() {
@@ -1092,23 +1103,23 @@ export class GlobeFallback2D {
   }
 
   _bindEvents() {
-    this.canvas.addEventListener('mousedown', (e) => { this._drag = true; this._prevX = e.clientX; });
-    window.addEventListener('mousemove', (e) => {
+    this._addListener(this.canvas, 'mousedown', (e) => { this._drag = true; this._prevX = e.clientX; });
+    this._addListener(window, 'mousemove', (e) => {
       if (!this._drag) return;
       const dx = e.clientX - this._prevX;
       this._rot += dx * 0.0045;
       this._prevX = e.clientX;
     });
-    window.addEventListener('mouseup', () => { this._drag = false; });
-    this.canvas.addEventListener('touchstart', (e) => { if (e.touches[0]) { this._drag = true; this._prevX = e.touches[0].clientX; } }, { passive: true });
-    this.canvas.addEventListener('touchmove', (e) => {
+    this._addListener(window, 'mouseup', () => { this._drag = false; });
+    this._addListener(this.canvas, 'touchstart', (e) => { if (e.touches[0]) { this._drag = true; this._prevX = e.touches[0].clientX; } }, { passive: true });
+    this._addListener(this.canvas, 'touchmove', (e) => {
       if (!this._drag || !e.touches[0]) return;
       const dx = e.touches[0].clientX - this._prevX;
       this._rot += dx * 0.0045;
       this._prevX = e.touches[0].clientX;
     }, { passive: true });
-    this.canvas.addEventListener('touchend', () => { this._drag = false; });
-    window.addEventListener('resize', () => this._resize());
+    this._addListener(this.canvas, 'touchend', () => { this._drag = false; });
+    this._addListener(window, 'resize', () => this._resize());
   }
 
   _project(lat, lon) {
@@ -1197,6 +1208,11 @@ export class GlobeFallback2D {
   destroy() {
     if (this._rafId) cancelAnimationFrame(this._rafId);
     this._rafId = null;
+    if (this._io) { this._io.disconnect(); this._io = null; }
+    for (const { target, type, fn, opts } of (this._listeners || [])) {
+      try { target.removeEventListener(type, fn, opts); } catch (_) { /* ignore */ }
+    }
+    this._listeners = [];
   }
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -800,8 +800,14 @@ function renderProjectCard(project, i) {
     .join('');
   const bgSrc = project.bg || '';
   const hasBg = Boolean(bgSrc);
+  /* Make the url() root-absolute. Chromium resolves a relative url() inside a
+     CSS custom property against the stylesheet that *uses* var(--card-bg)
+     (the bundled /assets/styles.css), not the document — so a bare
+     "img/projects/…" path would 404 at /assets/img/projects/…. Leading "/"
+     pins it to the site root. */
+  const bgUrl = /^(https?:|data:|\/)/.test(bgSrc) ? bgSrc : '/' + bgSrc;
   const style = hasBg
-    ? ' style="--card-bg: url(\'' + escapeHtml(bgSrc) + '\')"'
+    ? ' style="--card-bg: url(\'' + escapeHtml(bgUrl) + '\')"'
     : '';
   const cls = 'project-card' + (hasBg ? ' project-card--has-bg' : '');
   return '<a href="' + escapeHtml(project.url || '#') + '" class="' + cls + '" data-animate data-delay="' + (i * 80) + '"' + style + '>' +

--- a/js/main.js
+++ b/js/main.js
@@ -37,7 +37,7 @@ import { CV_CAREER as DEFAULT_CV_CAREER, CV_EDUCATION as DEFAULT_CV_EDUCATION, C
 import './europe-map.js';
 
 /* Shared environment helpers */
-import { getTopoJSON, isLowPowerDevice, prefersReducedMotion, hasWebGLSupport } from './utils.js';
+import { isLowPowerDevice, prefersReducedMotion, hasWebGLSupport } from './utils.js';
 
 /* Theme colours — single source of truth (data/palettes.yaml → js/theme.js) */
 import { THEME, glvec, rgba } from './theme.js';

--- a/js/main.js
+++ b/js/main.js
@@ -16,11 +16,15 @@
    `npm run generate-theme`.
    ============================================================ */
 
-/* ─── Three.js test mocking helpers ────────────────────────────
-   Re-exported from three-context.js so tests can swap THREE for a
-   minimal mock; every consumer module that uses Three.js subscribes
-   to the swap via the context. */
-export { __setThreeForTests, __resetThreeForTests } from './three-context.js';
+/* ─── Three.js loading strategy ─────────────────────────────────
+   neural-net.js and globe.js (and through them three-context.js → the whole
+   `three` package) are loaded on demand via dynamic import() at their init
+   sites below. That keeps Three.js in a lazy chunk instead of the per-page
+   bundle, so it never ships to pages without a 3D canvas (cv, projects, 404,
+   project pages) and is off the critical path on the home page.
+   Do NOT statically import three-context.js / globe.js / neural-net.js here —
+   that pulls all of Three.js back into every page. Tests import the THREE
+   mock hook (__setThreeForTests) directly from ./three-context.js. */
 
 /* ─── Data files ──────────────────────────────────────────
    PROJECTS / PUBLICATIONS / CV_* are imported by name; render
@@ -45,14 +49,12 @@ import { THEME, glvec, rgba } from './theme.js';
 /* '#rrggbb' → GLSL `vec3(r, g, b)` literal. */
 const v3 = (hex) => `vec3(${glvec(hex).join(', ')})`;
 
-/* Hero neural-network animation (extracted module) */
-import { NeuralNetwork, NeuralNetwork2D } from './neural-net.js';
-
-/* Hero name iridescent WebGL shader (extracted module) */
+/* Hero name iridescent WebGL shader (raw WebGL, no Three.js) */
 import { HeroNameShader } from './hero-shader.js';
 
-/* 3D Globe + 2D fallback + geocoding (extracted module) */
-import { geocodeLocations, Globe3D, GlobeFallback2D } from './globe.js';
+/* neural-net.js (NeuralNetwork/NeuralNetwork2D) and globe.js (Globe3D/
+   GlobeFallback2D/geocodeLocations) are dynamically imported at their init
+   sites below — see the Three.js loading-strategy note at the top. */
 
 /* DOM animations: scroll-driven, card tilt, magnetic buttons, parallax (extracted) */
 import {
@@ -1284,11 +1286,14 @@ class NoiseGradient {
   }
 }
 
-/* Test surface — ES module exports */
+/* Test surface — ES module exports.
+   The Three.js-backed classes (Globe3D, GlobeFallback2D, NeuralNetwork,
+   NeuralNetwork2D) and geocodeLocations are intentionally NOT re-exported
+   here: doing so would static-link globe.js/neural-net.js (and all of
+   Three.js) back into the main chunk. Tests import them from their source
+   modules instead. */
 export {
   formatIsoDate,
-  geocodeLocations,
-  Globe3D,
   renderPublications,
   renderProjects,
   renderProjectCard,
@@ -1310,11 +1315,8 @@ export {
   initScrollReveal,
   initCounters,
   animateCounter,
-  NeuralNetwork,
-  NeuralNetwork2D,
   HeroNameShader,
   NoiseGradient,
-  GlobeFallback2D,
   decodeBase64,
   getObfuscatedContactEmail,
   initEmailObfuscation,
@@ -1522,15 +1524,18 @@ if (typeof document !== 'undefined') {
     noiseCanvas.style.display = 'none';
   }
 
-  /* Three.js neural network — falls back to Canvas2D when WebGL is missing */
+  /* Three.js neural network — falls back to Canvas2D when WebGL is missing.
+     Dynamically imported so Three.js stays out of the main chunk. */
   const canvas = document.getElementById('neural-canvas');
   if (canvas) {
     if (prefersReducedMotion()) {
       canvas.style.display = 'none';
-    } else if (hasWebGLSupport()) {
-      _disposables.push(new NeuralNetwork(canvas));
     } else {
-      _disposables.push(new NeuralNetwork2D(canvas));
+      import('./neural-net.js').then(({ NeuralNetwork, NeuralNetwork2D }) => {
+        _disposables.push(
+          hasWebGLSupport() ? new NeuralNetwork(canvas) : new NeuralNetwork2D(canvas),
+        );
+      });
     }
   }
 
@@ -1558,16 +1563,20 @@ if (typeof document !== 'undefined') {
   /* Three.js Globe — geocode any entries missing lat/lon, then build */
   const globeCanvas = document.getElementById('globe-canvas');
   if (globeCanvas && typeof LOCATIONS !== 'undefined') {
+    /* Dynamically imported (Three.js) and only when the globe nears the
+       viewport — so Three.js downloads lazily, on scroll, not on load. */
     _lazyOnViewport(globeCanvas, () => {
-      geocodeLocations(LOCATIONS).then(() => {
-        const inst = (prefersReducedMotion() || !hasWebGLSupport())
-          ? new GlobeFallback2D(globeCanvas)
-          : new Globe3D(globeCanvas);
-        _disposables.push(inst);
-        /* Render the SR-accessible alternative list once the location data
-           is final (i.e. all geocoding has resolved). */
-        const a11yList = document.getElementById('globe-a11y-list');
-        if (a11yList) renderGlobeA11yList(a11yList, LOCATIONS);
+      import('./globe.js').then(({ geocodeLocations, Globe3D, GlobeFallback2D }) => {
+        geocodeLocations(LOCATIONS).then(() => {
+          const inst = (prefersReducedMotion() || !hasWebGLSupport())
+            ? new GlobeFallback2D(globeCanvas)
+            : new Globe3D(globeCanvas);
+          _disposables.push(inst);
+          /* Render the SR-accessible alternative list once the location data
+             is final (i.e. all geocoding has resolved). */
+          const a11yList = document.getElementById('globe-a11y-list');
+          if (a11yList) renderGlobeA11yList(a11yList, LOCATIONS);
+        });
       });
     });
   }

--- a/js/neural-net.js
+++ b/js/neural-net.js
@@ -74,24 +74,27 @@ export class NeuralNetwork {
     this._initLines();
     this._onResize();
 
+    /* Track every listener + observer so destroy() can tear them all down. */
+    this._listeners = [];
+
     if (typeof canvas.addEventListener === 'function') {
-      canvas.addEventListener('webglcontextlost', (e) => {
+      this._addListener(canvas, 'webglcontextlost', (e) => {
         e.preventDefault();
         this.frameId = null;
       }, false);
-      canvas.addEventListener('webglcontextrestored', () => {
+      this._addListener(canvas, 'webglcontextrestored', () => {
         this._onResize();
         if (!this.frameId) this._animate();
       }, false);
     }
 
-    window.addEventListener('resize', () => this._onResize());
-    window.addEventListener('mousemove', e => {
+    this._addListener(window, 'resize', () => this._onResize());
+    this._addListener(window, 'mousemove', e => {
       this.mouse.x = e.clientX - window.innerWidth / 2;
       this.mouse.y = -(e.clientY - window.innerHeight / 2);
     }, { passive: true });
     /* Touch support */
-    window.addEventListener('touchmove', e => {
+    this._addListener(window, 'touchmove', e => {
       if (!e.touches[0]) return;
       this.mouse.x = e.touches[0].clientX - window.innerWidth / 2;
       this.mouse.y = -(e.touches[0].clientY - window.innerHeight / 2);
@@ -99,18 +102,25 @@ export class NeuralNetwork {
 
     /* Pause rendering when the section scrolls out of view */
     this._visible = true;
-    const _ioNN = new IntersectionObserver(([e]) => {
+    this._io = new IntersectionObserver(([e]) => {
       this._visible = e.isIntersecting;
       if (this._visible && !this.frameId) this._animate();
     }, { threshold: 0 });
-    _ioNN.observe(canvas);
+    this._io.observe(canvas);
 
     /* Pause rendering when the browser tab is hidden */
-    document.addEventListener('visibilitychange', () => {
+    this._addListener(document, 'visibilitychange', () => {
       if (!document.hidden && !this.frameId) this._animate();
     });
 
     this._animate();
+  }
+
+  /* Track + register a listener so destroy() can later remove it. */
+  _addListener(target, type, fn, opts) {
+    if (!target || typeof target.addEventListener !== 'function') return;
+    target.addEventListener(type, fn, opts);
+    this._listeners.push({ target, type, fn, opts });
   }
 
   /* Create a soft glow disc texture for each particle */
@@ -301,6 +311,12 @@ export class NeuralNetwork {
 
   destroy() {
     if (this.frameId) cancelAnimationFrame(this.frameId);
+    this.frameId = null;
+    if (this._io) { this._io.disconnect(); this._io = null; }
+    for (const { target, type, fn, opts } of (this._listeners || [])) {
+      try { target.removeEventListener(type, fn, opts); } catch (_) { /* ignore */ }
+    }
+    this._listeners = [];
   }
 }
 
@@ -308,6 +324,8 @@ export class NeuralNetwork {
 export class NeuralNetwork2D {
   constructor(canvas) {
     this.canvas = canvas;
+    this._listeners = [];
+    this._io = null;
     this.ctx = canvas.getContext('2d', { alpha: true });
     if (!this.ctx) return;
     this.mouse = { x: 0, y: 0 };
@@ -325,28 +343,35 @@ export class NeuralNetwork2D {
     this._onResize();
     for (let i = 0; i < this.count; i++) this.points.push(this._newPoint());
 
-    window.addEventListener('resize', () => this._onResize());
-    window.addEventListener('mousemove', (e) => {
+    this._addListener(window, 'resize', () => this._onResize());
+    this._addListener(window, 'mousemove', (e) => {
       this.mouse.x = e.clientX;
       this.mouse.y = e.clientY;
     }, { passive: true });
-    window.addEventListener('touchmove', (e) => {
+    this._addListener(window, 'touchmove', (e) => {
       if (!e.touches[0]) return;
       this.mouse.x = e.touches[0].clientX;
       this.mouse.y = e.touches[0].clientY;
     }, { passive: true });
 
-    const io = new IntersectionObserver(([entry]) => {
+    this._io = new IntersectionObserver(([entry]) => {
       this._visible = entry.isIntersecting;
       if (this._visible && !this.frameId) this._animate();
     }, { threshold: 0 });
-    io.observe(canvas);
+    this._io.observe(canvas);
 
-    document.addEventListener('visibilitychange', () => {
+    this._addListener(document, 'visibilitychange', () => {
       if (!document.hidden && !this.frameId) this._animate();
     });
 
     this._animate();
+  }
+
+  /* Track + register a listener so destroy() can later remove it. */
+  _addListener(target, type, fn, opts) {
+    if (!target || typeof target.addEventListener !== 'function') return;
+    target.addEventListener(type, fn, opts);
+    this._listeners.push({ target, type, fn, opts });
   }
 
   _newPoint() {
@@ -436,5 +461,10 @@ export class NeuralNetwork2D {
   destroy() {
     if (this.frameId) cancelAnimationFrame(this.frameId);
     this.frameId = null;
+    if (this._io) { this._io.disconnect(); this._io = null; }
+    for (const { target, type, fn, opts } of (this._listeners || [])) {
+      try { target.removeEventListener(type, fn, opts); } catch (_) { /* ignore */ }
+    }
+    this._listeners = [];
   }
 }

--- a/js/theme.js
+++ b/js/theme.js
@@ -18,7 +18,7 @@ export const THEME = {
   bgAlt: '#0f1a14',
   text: '#e8eee5',
   textMuted: '#8a948b',
-  textFaint: '#5e6862',
+  textFaint: '#767f78',
   accent: '#c8a44d',
   accentHi: '#dcb968',
   accent2: '#6db088',

--- a/projects/audience-engagement.html
+++ b/projects/audience-engagement.html
@@ -9,19 +9,19 @@
   <meta name="description" content="A multi-modal system that measures audience engagement at live events by fusing computer vision with WiFi/Bluetooth signal analysis. Designed, implemented, and validated at Vicomtech in 2020, and released as open-source software." />
   <meta name="author" content="Stefano Masneri" />
   <meta name="robots" content="index, follow, noai, noimageai" />
-  <title>Multi-modal Audience Engagement Measurement System — Stefano Masneri</title>
+  <title>Audience Engagement Measurement System — Stefano Masneri</title>
   <link rel="canonical" href="https://stefanomasneri.com/projects/audience-engagement.html" />
 
   <meta property="og:type"        content="article" />
   <meta property="og:site_name"   content="Stefano Masneri" />
   <meta property="og:locale"      content="en_GB" />
   <meta property="og:url"         content="https://stefanomasneri.com/projects/audience-engagement.html" />
-  <meta property="og:title"       content="Multi-modal Audience Engagement Measurement System — Stefano Masneri" />
+  <meta property="og:title"       content="Audience Engagement Measurement System — Stefano Masneri" />
   <meta property="og:description" content="A multi-modal system that measures audience engagement at live events by fusing computer vision with WiFi/Bluetooth signal analysis. Designed, implemented, and validated at Vicomtech in 2020, and released as open-source software." />
   <meta property="og:image"       content="https://stefanomasneri.com/img/projects/audience-engagement-bg.webp" />
   <meta property="og:image:alt"   content="Multi-modal Audience Engagement Measurement System" />
   <meta name="twitter:card"        content="summary_large_image" />
-  <meta name="twitter:title"       content="Multi-modal Audience Engagement Measurement System — Stefano Masneri" />
+  <meta name="twitter:title"       content="Audience Engagement Measurement System — Stefano Masneri" />
   <meta name="twitter:description" content="A multi-modal system that measures audience engagement at live events by fusing computer vision with WiFi/Bluetooth signal analysis. Designed, implemented, and validated at Vicomtech in 2020, and released as open-source software." />
   <meta name="twitter:image"       content="https://stefanomasneri.com/img/projects/audience-engagement-bg.webp" />
   <meta name="twitter:image:alt"   content="Multi-modal Audience Engagement Measurement System" />

--- a/projects/avatech.html
+++ b/projects/avatech.html
@@ -9,19 +9,19 @@
   <meta name="description" content="AVATecH was a joint Fraunhofer / Max Planck project that brought state-of-the-art audio and video pattern recognition into ELAN — the de-facto annotation tool used by linguists, anthropologists, and psychologists worldwide — turning weeks of manual labelling into minutes of supervised review." />
   <meta name="author" content="Stefano Masneri" />
   <meta name="robots" content="index, follow, noai, noimageai" />
-  <title>AVATecH: Automated Annotation of Audio/Video Corpora for Humanities Research — Stefano Masneri</title>
+  <title>AVATecH: AI Annotation for Humanities — Stefano Masneri</title>
   <link rel="canonical" href="https://stefanomasneri.com/projects/avatech.html" />
 
   <meta property="og:type"        content="article" />
   <meta property="og:site_name"   content="Stefano Masneri" />
   <meta property="og:locale"      content="en_GB" />
   <meta property="og:url"         content="https://stefanomasneri.com/projects/avatech.html" />
-  <meta property="og:title"       content="AVATecH: Automated Annotation of Audio/Video Corpora for Humanities Research — Stefano Masneri" />
+  <meta property="og:title"       content="AVATecH: AI Annotation for Humanities — Stefano Masneri" />
   <meta property="og:description" content="AVATecH was a joint Fraunhofer / Max Planck project that brought state-of-the-art audio and video pattern recognition into ELAN — the de-facto annotation tool used by linguists, anthropologists, and psychologists worldwide — turning weeks of manual labelling into minutes of supervised review." />
   <meta property="og:image"       content="https://stefanomasneri.com/img/projects/avatech-bg.jpg" />
   <meta property="og:image:alt"   content="AVATecH: Automated Annotation of Audio/Video Corpora for Humanities Research" />
   <meta name="twitter:card"        content="summary_large_image" />
-  <meta name="twitter:title"       content="AVATecH: Automated Annotation of Audio/Video Corpora for Humanities Research — Stefano Masneri" />
+  <meta name="twitter:title"       content="AVATecH: AI Annotation for Humanities — Stefano Masneri" />
   <meta name="twitter:description" content="AVATecH was a joint Fraunhofer / Max Planck project that brought state-of-the-art audio and video pattern recognition into ELAN — the de-facto annotation tool used by linguists, anthropologists, and psychologists worldwide — turning weeks of manual labelling into minutes of supervised review." />
   <meta name="twitter:image"       content="https://stefanomasneri.com/img/projects/avatech-bg.jpg" />
   <meta name="twitter:image:alt"   content="AVATecH: Automated Annotation of Audio/Video Corpora for Humanities Research" />

--- a/projects/clear-architecture.html
+++ b/projects/clear-architecture.html
@@ -11,20 +11,20 @@
     content="cleAR is a modular, interoperable architecture for building multi-user augmented reality applications in education. Designed from the ground up to bridge the gap between AR's potential and its limited classroom adoption, it was the core contribution of my PhD research." />
   <meta name="author" content="Stefano Masneri" />
   <meta name="robots" content="index, follow, noai, noimageai" />
-  <title>cleAR: Interoperable Architecture for Multi-User AR — Stefano Masneri</title>
+  <title>cleAR: Architecture for Multi-User AR — Stefano Masneri</title>
   <link rel="canonical" href="https://stefanomasneri.com/projects/clear-architecture.html" />
 
   <meta property="og:type" content="article" />
   <meta property="og:site_name"   content="Stefano Masneri" />
   <meta property="og:locale"      content="en_GB" />
   <meta property="og:url" content="https://stefanomasneri.com/projects/clear-architecture.html" />
-  <meta property="og:title" content="cleAR: Interoperable Architecture for Multi-User AR — Stefano Masneri" />
+  <meta property="og:title" content="cleAR: Architecture for Multi-User AR — Stefano Masneri" />
   <meta property="og:description"
     content="cleAR is a modular, interoperable architecture for building multi-user augmented reality applications in education. Designed from the ground up to bridge the gap between AR's potential and its limited classroom adoption, it was the core contribution of my PhD research." />
   <meta property="og:image" content="https://stefanomasneri.com/img/projects/clear-architecture.jpg" />
   <meta property="og:image:alt"   content="cleAR: Interoperable Architecture for Multi-User AR" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="cleAR: Interoperable Architecture for Multi-User AR — Stefano Masneri" />
+  <meta name="twitter:title" content="cleAR: Architecture for Multi-User AR — Stefano Masneri" />
   <meta name="twitter:description"
     content="cleAR is a modular, interoperable architecture for building multi-user augmented reality applications in education. Designed from the ground up to bridge the gap between AR's potential and its limited classroom adoption, it was the core contribution of my PhD research." />
   <meta name="twitter:image"       content="https://stefanomasneri.com/img/projects/clear-architecture.jpg" />

--- a/projects/mpi-brain-research.html
+++ b/projects/mpi-brain-research.html
@@ -9,19 +9,19 @@
   <meta name="description" content="Two years as a scientific software developer in Gilles Laurent's department at the Max Planck Institute for Brain Research in Frankfurt, building MATLAB analysis pipelines and R/Shiny web apps for electrophysiologists studying sleep in bearded dragons and visual processing in ex-vivo turtle brains." />
   <meta name="author" content="Stefano Masneri" />
   <meta name="robots" content="index, follow, noai, noimageai" />
-  <title>MPI for Brain Research: Software for Reptilian Neuroscience — Stefano Masneri</title>
+  <title>Reptilian Neuroscience Software at MPI — Stefano Masneri</title>
   <link rel="canonical" href="https://stefanomasneri.com/projects/mpi-brain-research.html" />
 
   <meta property="og:type"        content="article" />
   <meta property="og:site_name"   content="Stefano Masneri" />
   <meta property="og:locale"      content="en_GB" />
   <meta property="og:url"         content="https://stefanomasneri.com/projects/mpi-brain-research.html" />
-  <meta property="og:title"       content="MPI for Brain Research: Software for Reptilian Neuroscience — Stefano Masneri" />
+  <meta property="og:title"       content="Reptilian Neuroscience Software at MPI — Stefano Masneri" />
   <meta property="og:description" content="Two years as a scientific software developer in Gilles Laurent's department at the Max Planck Institute for Brain Research in Frankfurt, building MATLAB analysis pipelines and R/Shiny web apps for electrophysiologists studying sleep in bearded dragons and visual processing in ex-vivo turtle brains." />
   <meta property="og:image"       content="https://stefanomasneri.com/img/projects/mpi-brain-bg.jpeg" />
   <meta property="og:image:alt"   content="MPI for Brain Research: Software for Reptilian Neuroscience" />
   <meta name="twitter:card"        content="summary_large_image" />
-  <meta name="twitter:title"       content="MPI for Brain Research: Software for Reptilian Neuroscience — Stefano Masneri" />
+  <meta name="twitter:title"       content="Reptilian Neuroscience Software at MPI — Stefano Masneri" />
   <meta name="twitter:description" content="Two years as a scientific software developer in Gilles Laurent's department at the Max Planck Institute for Brain Research in Frankfurt, building MATLAB analysis pipelines and R/Shiny web apps for electrophysiologists studying sleep in bearded dragons and visual processing in ex-vivo turtle brains." />
   <meta name="twitter:image"       content="https://stefanomasneri.com/img/projects/mpi-brain-bg.jpeg" />
   <meta name="twitter:image:alt"   content="MPI for Brain Research: Software for Reptilian Neuroscience" />

--- a/projects/traction.html
+++ b/projects/traction.html
@@ -9,19 +9,19 @@
   <meta name="description" content="TRACTION was a Horizon 2020 project, coordinated by Vicomtech, that used opera as a vehicle for social inclusion. My work centred on the Co-creation Stage — the real-time distributed performance tool — spanning development, user-requirements gathering, evaluation, and direct engagement with artistic and community partners across Barcelona, Leiria and Ireland." />
   <meta name="author" content="Stefano Masneri" />
   <meta name="robots" content="index, follow, noai, noimageai" />
-  <title>TRACTION: Opera Co-creation for Social Transformation — Stefano Masneri</title>
+  <title>TRACTION: Opera Co-creation for Inclusion — Stefano Masneri</title>
   <link rel="canonical" href="https://stefanomasneri.com/projects/traction.html" />
 
   <meta property="og:type"        content="article" />
   <meta property="og:site_name"   content="Stefano Masneri" />
   <meta property="og:locale"      content="en_GB" />
   <meta property="og:url"         content="https://stefanomasneri.com/projects/traction.html" />
-  <meta property="og:title"       content="TRACTION: Opera Co-creation for Social Transformation — Stefano Masneri" />
+  <meta property="og:title"       content="TRACTION: Opera Co-creation for Inclusion — Stefano Masneri" />
   <meta property="og:description" content="TRACTION was a Horizon 2020 project, coordinated by Vicomtech, that used opera as a vehicle for social inclusion. My work centred on the Co-creation Stage — the real-time distributed performance tool — spanning development, user-requirements gathering, evaluation, and direct engagement with artistic and community partners across Barcelona, Leiria and Ireland." />
   <meta property="og:image"       content="https://stefanomasneri.com/img/projects/traction-bg.jpg" />
   <meta property="og:image:alt"   content="TRACTION: Opera Co-creation for Social Transformation" />
   <meta name="twitter:card"        content="summary_large_image" />
-  <meta name="twitter:title"       content="TRACTION: Opera Co-creation for Social Transformation — Stefano Masneri" />
+  <meta name="twitter:title"       content="TRACTION: Opera Co-creation for Inclusion — Stefano Masneri" />
   <meta name="twitter:description" content="TRACTION was a Horizon 2020 project, coordinated by Vicomtech, that used opera as a vehicle for social inclusion. My work centred on the Co-creation Stage — the real-time distributed performance tool — spanning development, user-requirements gathering, evaluation, and direct engagement with artistic and community partners across Barcelona, Leiria and Ireland." />
   <meta name="twitter:image"       content="https://stefanomasneri.com/img/projects/traction-bg.jpg" />
   <meta name="twitter:image:alt"   content="TRACTION: Opera Co-creation for Social Transformation" />

--- a/projects/ufc-fighter-tracking.html
+++ b/projects/ufc-fighter-tracking.html
@@ -9,19 +9,19 @@
   <meta name="description" content="End-to-end real-time analytics for live UFC events: stereo computer vision in the truss above the octagon, accelerometers in the gloves, GPU inference at the venue, and statistics streamed to fans worldwide. Built at AGT International in 2017 and demoed live by our CEO during Werner Vogels' keynote at AWS re:Invent 2017." />
   <meta name="author" content="Stefano Masneri" />
   <meta name="robots" content="index, follow, noai, noimageai" />
-  <title>UFC Fighter Tracking: Multi-Modal Sensing in the Octagon — Stefano Masneri</title>
+  <title>UFC Fighter Tracking: Multi-Modal Sensing — Stefano Masneri</title>
   <link rel="canonical" href="https://stefanomasneri.com/projects/ufc-fighter-tracking.html" />
 
   <meta property="og:type"        content="article" />
   <meta property="og:site_name"   content="Stefano Masneri" />
   <meta property="og:locale"      content="en_GB" />
   <meta property="og:url"         content="https://stefanomasneri.com/projects/ufc-fighter-tracking.html" />
-  <meta property="og:title"       content="UFC Fighter Tracking: Multi-Modal Sensing in the Octagon — Stefano Masneri" />
+  <meta property="og:title"       content="UFC Fighter Tracking: Multi-Modal Sensing — Stefano Masneri" />
   <meta property="og:description" content="End-to-end real-time analytics for live UFC events: stereo computer vision in the truss above the octagon, accelerometers in the gloves, GPU inference at the venue, and statistics streamed to fans worldwide. Built at AGT International in 2017 and demoed live by our CEO during Werner Vogels' keynote at AWS re:Invent 2017." />
   <meta property="og:image"       content="https://stefanomasneri.com/img/projects/ufc-octagon-bg.webp" />
   <meta property="og:image:alt"   content="UFC Fighter Tracking: Multi-Modal Sensing in the Octagon" />
   <meta name="twitter:card"        content="summary_large_image" />
-  <meta name="twitter:title"       content="UFC Fighter Tracking: Multi-Modal Sensing in the Octagon — Stefano Masneri" />
+  <meta name="twitter:title"       content="UFC Fighter Tracking: Multi-Modal Sensing — Stefano Masneri" />
   <meta name="twitter:description" content="End-to-end real-time analytics for live UFC events: stereo computer vision in the truss above the octagon, accelerometers in the gloves, GPU inference at the venue, and statistics streamed to fans worldwide. Built at AGT International in 2017 and demoed live by our CEO during Werner Vogels' keynote at AWS re:Invent 2017." />
   <meta name="twitter:image"       content="https://stefanomasneri.com/img/projects/ufc-octagon-bg.webp" />
   <meta name="twitter:image:alt"   content="UFC Fighter Tracking: Multi-Modal Sensing in the Octagon" />

--- a/test/main.node.test.mjs
+++ b/test/main.node.test.mjs
@@ -109,6 +109,7 @@ test('geocodeLocations fills coordinates on successful lookup', async () => {
   const sample = { pins: [{ name: 'Paris, France', info: 'Holiday' }] };
   const prevFetch = global.fetch;
   global.fetch = async () => ({
+    ok: true,
     json: async () => [{ lat: '48.8566', lon: '2.3522' }],
   });
   try {
@@ -116,6 +117,26 @@ test('geocodeLocations fills coordinates on successful lookup', async () => {
     assert.equal(sample.pins[0].lat, 48.8566);
     assert.equal(sample.pins[0].lon, 2.3522);
     assert.equal(sample.pins[0]._skip, undefined);
+  } finally {
+    global.fetch = prevFetch;
+  }
+});
+
+test('geocodeLocations marks item as skipped on HTTP error response', async () => {
+  const sample = { pins: [{ name: 'Paris, France', info: 'Holiday' }] };
+  const prevFetch = global.fetch;
+  /* A 429/5xx returns ok:false; res.json() would parse a non-JSON body —
+     the guard must skip the pin rather than throw an unhandled error. */
+  global.fetch = async () => ({
+    ok: false,
+    status: 429,
+    json: async () => { throw new Error('Unexpected token < in JSON'); },
+  });
+  try {
+    await geocodeLocations(sample);
+    assert.equal(sample.pins[0]._skip, true);
+    assert.equal(sample.pins[0].lat, undefined);
+    assert.equal(sample.pins[0].lon, undefined);
   } finally {
     global.fetch = prevFetch;
   }
@@ -1817,13 +1838,18 @@ test('GlobeFallback2D skips pins marked with _skip', () => {
 
 /* ─── initCardFlip tests ──────────────────────────────────── */
 
-function makeCard(id) {
+function makeCard(id, title = 'Sample') {
   const listeners = {};
+  const attributes = {};
   const card = {
     id,
     classList: makeClassList(),
     style: { transform: '', transition: '' },
+    attributes,
     addEventListener(type, fn) { listeners[type] = fn; },
+    setAttribute(name, value) { attributes[name] = String(value); },
+    getAttribute(name) { return attributes[name]; },
+    querySelector(sel) { return sel === '.card-title' ? { textContent: title } : null; },
     _listeners: listeners,
   };
   return card;
@@ -1910,6 +1936,33 @@ test('initCardFlip attaches listeners to all research grid cards', () => {
       assert.equal(card.classList.contains('is-flipped'), true,
         `Card ${card.id} should be flippable`);
     });
+  } finally {
+    global.document = prevDoc;
+  }
+});
+
+test('initCardFlip makes cards keyboard-operable with ARIA disclosure state', () => {
+  const prevDoc = global.document;
+  const card = makeCard('k1', 'Generative AI & LLMs');
+  global.document = {
+    querySelectorAll(sel) {
+      return sel === '#research-grid .research-card' ? [card] : [];
+    },
+  };
+  try {
+    initCardFlip();
+    assert.equal(card.getAttribute('role'), 'button');
+    assert.equal(card.getAttribute('tabindex'), '0');
+    assert.equal(card.getAttribute('aria-expanded'), 'false');
+    assert.equal(card.getAttribute('aria-label'), 'Generative AI & LLMs — show details');
+    /* Enter flips the card and reflects expanded state */
+    card._listeners.keydown({ key: 'Enter', preventDefault() {} });
+    assert.equal(card.classList.contains('is-flipped'), true);
+    assert.equal(card.getAttribute('aria-expanded'), 'true');
+    /* Space flips back */
+    card._listeners.keydown({ key: ' ', preventDefault() {} });
+    assert.equal(card.classList.contains('is-flipped'), false);
+    assert.equal(card.getAttribute('aria-expanded'), 'false');
   } finally {
     global.document = prevDoc;
   }

--- a/test/main.node.test.mjs
+++ b/test/main.node.test.mjs
@@ -2084,8 +2084,8 @@ test('renderProjects uses bg image as CSS background when provided', () => {
       description: 'A project with a background image.',
       url: 'projects/with-bg.html',
     }]);
-    // bg URL should end up as a CSS custom property on the card
-    assert.match(grid.innerHTML, /--card-bg:\s*url\(['"]?img\/projects\/with-bg-hero\.jpg['"]?\)/);
+    // bg URL should end up as a root-absolute CSS custom property on the card
+    assert.match(grid.innerHTML, /--card-bg:\s*url\(['"]?\/img\/projects\/with-bg-hero\.jpg['"]?\)/);
     // has-bg class toggled when bg is present
     assert.match(grid.innerHTML, /project-card--has-bg/);
   } finally {

--- a/test/main.node.test.mjs
+++ b/test/main.node.test.mjs
@@ -7,8 +7,6 @@ import { fileURLToPath } from 'node:url';
 
 import {
   formatIsoDate,
-  geocodeLocations,
-  Globe3D,
   renderPublications,
   setFooterYear,
   initNavbar,
@@ -16,7 +14,6 @@ import {
   initScrollReveal,
   initCounters,
   animateCounter,
-  NeuralNetwork,
   HeroNameShader,
   decodeBase64,
   getObfuscatedContactEmail,
@@ -31,16 +28,17 @@ import {
   initMagneticButtons,
   initScroll3D,
   initBackToTop,
-  NeuralNetwork2D,
   NoiseGradient,
-  GlobeFallback2D,
   initCardFlip,
   renderProjects,
   PROJECTS_MAX_HOMEPAGE,
   initCommandPalette,
-  __setThreeForTests,
-  __resetThreeForTests,
 } from '../js/main.js';
+/* Three.js-backed classes are now imported from their source modules — main.js
+   dynamically imports them so Three.js is not in the per-page bundle. */
+import { geocodeLocations, Globe3D, GlobeFallback2D } from '../js/globe.js';
+import { NeuralNetwork, NeuralNetwork2D } from '../js/neural-net.js';
+import { __setThreeForTests, __resetThreeForTests } from '../js/three-context.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');


### PR DESCRIPTION
## Summary

A pre-launch review pass across accessibility, SEO, performance, and code quality, plus two bug fixes found during verification. No visual redesign — the look is unchanged (verified in a headless browser against the production build). 3 commits, 18 files, all 422 tests passing and `npm run build` clean.

## Accessibility
- **Contrast:** `textFaint` failed WCAG AA (~3.3:1 on the dark background). Bumped it in all three palettes to ~4.6:1 and regenerated the theme. Affected real UI: contact labels, command-palette hints, globe subtitle.
- **Keyboard:** research flip-cards were click-only; their back faces hold links found nowhere else. They're now keyboard-operable (`role="button"`, `tabindex`, `aria-expanded`, Enter/Space), so the back-face links become reachable.
- **Headings:** promoted the "Where I've Been" `h3` to `h2` (was a heading-level skip).
- **Decorative canvas:** marked `#europe-canvas` `aria-hidden` (the 3D globe already exposes a screen-reader location list).

## SEO / content
- Fixed a job-title contradiction: the home page meta/OG/Twitter said "Senior AI **Lead**" while the JSON-LD, body copy, CV, and manifest all said "Senior AI **Engineer**" → now consistent.
- Expanded the home page `<title>`/`og`/`twitter` to **"Stefano Masneri — Machine Learning, Computer Vision & AR"** (fuller keywords, still under the SERP truncation limit).
- Shortened six over-length project `<title>`s (avatech was 96 chars) so they no longer truncate in search; the visible H1s are unchanged.
- Lengthened the thin `cv.html` description.
- Removed a dead `cdnjs` preconnect/dns-prefetch (no CDN is used; it was blocked by the site's own CSP).

## Performance — Three.js lazy-load
- `neural-net.js` and `globe.js` (and through them all of `three`) are now loaded via dynamic `import()` at their init sites instead of being statically imported in `main.js`.
- **Per-page bundle: 627 kB → 76 kB (165 → 25 kB gzip).** Three.js (≈131 kB gzip) now ships as a lazy chunk that loads only when a 3D canvas is present — on the home page after first paint (the globe waits for scroll), and **never** on cv / projects / 404 / project pages.
- Tests import the Three.js-backed classes and the THREE mock hook from their source modules rather than via `main.js` re-exports (re-exporting them would have re-linked Three.js into the main chunk).

## Bug fixes
- **Project-card backgrounds 404'd in the build.** Cards set `--card-bg: url('img/projects/…')` inline; Chromium resolves a relative `url()` inside a CSS custom property against the *using* stylesheet (`/assets/styles.css`), not the document, so the path 404'd at `/assets/img/projects/…`. Now emitted as a root-absolute URL. Detail-page heroes were already correct (they use `../img/…`), so only `renderProjectCard` changed.
- **Geocoding:** added an `res.ok` guard before parsing the Nominatim response (a 429/5xx returned a non-JSON body that would throw).

## Code quality
- Added listener/observer cleanup to `destroy()` in `NeuralNetwork`, `NeuralNetwork2D`, `EuropeMap2D`, and `GlobeFallback2D` (they previously only cancelled the RAF, leaking listeners on bfcache re-entry).
- Removed an unused `getTopoJSON` import and a stale file-wide `eslint-disable`.
- Refreshed `TODO.md` (its globe-a11y and side-dot items were already shipped).

## Tests
- All 422 pass. Added coverage for the geocode HTTP-error path and the card keyboard/ARIA disclosure behavior; updated mocks/assertions affected by the changes above.

## Verification
Built `dist/` and drove it in a headless browser: home loads Three.js lazily with no page errors (hero neural net + globe both render); cv/projects never request Three.js; and home, projects listing, and project detail pages all load with **zero failed requests** with card backgrounds rendering.

https://claude.ai/code/session_011HU79D2hTGCeCcZgCnwXez

---
_Generated by [Claude Code](https://claude.ai/code/session_011HU79D2hTGCeCcZgCnwXez)_