### PR TITLE
Remove em dashes from all content and update Research section label

### DIFF
--- a/404.html
+++ b/404.html
@@ -9,7 +9,7 @@
   <!-- /generated:csp-meta -->
   <meta name="description" content="The page you’re looking for doesn’t exist on stefanomasneri.com. Head back to the home page to browse Stefano Masneri’s work." />
   <meta name="robots" content="noindex" />
-  <title>404 — Page Not Found · Stefano Masneri</title>
+  <title>404 | Page Not Found · Stefano Masneri</title>
   <link rel="canonical" href="https://stefanomasneri.com/" />
 
   <!-- A shared 404 link still gets a useful preview pointing at the home page. -->

--- a/cv.html
+++ b/cv.html
@@ -8,10 +8,10 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://nominatim.openstreetmap.org; media-src 'self'; worker-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; manifest-src 'self'; upgrade-insecure-requests" />
   <!-- /generated:csp-meta -->
   <meta name="description"
-    content="Curriculum Vitae of Stefano Masneri, Senior AI Engineer — 15+ years in machine learning, computer vision, AR and generative AI, with a PhD and 30+ publications." />
+    content="Curriculum Vitae of Stefano Masneri, Senior AI Engineer with 15+ years in machine learning, computer vision, AR and generative AI, with a PhD and 30+ publications." />
   <meta name="author" content="Stefano Masneri" />
   <meta name="robots" content="index, follow, noai, noimageai" />
-  <title>CV — Stefano Masneri, Senior AI Engineer</title>
+  <title>CV | Stefano Masneri, Senior AI Engineer</title>
   <link rel="canonical" href="https://stefanomasneri.com/cv.html" />
 
   <!-- JSON-LD structured data -->
@@ -20,8 +20,8 @@
     "@context": "https://schema.org",
     "@type": "ProfilePage",
     "url": "https://stefanomasneri.com/cv.html",
-    "name": "CV — Stefano Masneri, Senior AI Engineer",
-    "description": "Curriculum Vitae of Stefano Masneri, Senior AI Engineer — 15+ years in machine learning, computer vision, AR and generative AI, with a PhD and 30+ publications.",
+    "name": "CV | Stefano Masneri, Senior AI Engineer",
+    "description": "Curriculum Vitae of Stefano Masneri, Senior AI Engineer with 15+ years in machine learning, computer vision, AR and generative AI, with a PhD and 30+ publications.",
     "mainEntity": {
       "@type": "Person",
       "name": "Stefano Masneri",
@@ -49,7 +49,7 @@
   <!-- Open Graph / Twitter Card -->
   <meta property="og:type"        content="website" />
   <meta property="og:url"         content="https://stefanomasneri.com/cv.html" />
-  <meta property="og:title"       content="CV — Stefano Masneri, Senior AI Engineer" />
+  <meta property="og:title"       content="CV | Stefano Masneri, Senior AI Engineer" />
   <meta property="og:description" content="Work experience and education of Stefano Masneri, Senior AI Engineer." />
   <meta property="og:image"       content="https://stefanomasneri.com/img/screenshot-hero.png" />
   <meta property="og:image:width"  content="1200" />
@@ -58,7 +58,7 @@
   <meta property="og:locale"      content="en_GB" />
   <meta property="og:site_name"   content="Stefano Masneri" />
   <meta name="twitter:card"        content="summary_large_image" />
-  <meta name="twitter:title"       content="CV — Stefano Masneri, Senior AI Engineer" />
+  <meta name="twitter:title"       content="CV | Stefano Masneri, Senior AI Engineer" />
   <meta name="twitter:description" content="Work experience and education of Stefano Masneri, Senior AI Engineer." />
   <meta name="twitter:image"       content="https://stefanomasneri.com/img/screenshot-hero.png" />
   <meta name="twitter:image:alt"   content="Stefano Masneri personal website" />

--- a/data/cv.js
+++ b/data/cv.js
@@ -66,7 +66,7 @@ export const CV_CAREER = [
 export const CV_EDUCATION = [
   {
     year:            '2019 – 2024',
-    degree:          'PhD — Computer Science',
+    degree:          'PhD in Computer Science',
     institution:     'Euskal Herriko Unibertsitatea (UPV/EHU)',
     location:        'Bilbao, ES',
     description:     'Thesis: "A Novel Architecture for Collaborative Augmented Reality Experiences for Education." Graduated cum laude.',
@@ -74,13 +74,13 @@ export const CV_EDUCATION = [
   },
   {
     year:        '2005 – 2008',
-    degree:      'MSc — Telecommunications Engineering',
+    degree:      'MSc in Telecommunications Engineering',
     institution: 'Università degli Studi di Brescia',
     location:    'Brescia, IT',
   },
   {
     year:        '2000 – 2005',
-    degree:      'BSc — Information Technology',
+    degree:      'BSc in Information Technology',
     institution: 'Università degli Studi di Brescia',
     location:    'Brescia, IT',
   },
@@ -147,19 +147,19 @@ export const CV_SKILLS = {
     },
     {
       name:        'Spanish',
-      proficiency: 'C2 — Proficient',
+      proficiency: 'C2: Proficient',
     },
     {
       name:        'English',
-      proficiency: 'C2 — Proficient',
+      proficiency: 'C2: Proficient',
     },
     {
       name:        'German',
-      proficiency: 'B2 — Upper-Intermediate',
+      proficiency: 'B2: Upper-Intermediate',
     },
     {
       name:        'Basque',
-      proficiency: 'B1 — Intermediate',
+      proficiency: 'B1: Intermediate',
     },
   ],
 };

--- a/data/cv.yaml
+++ b/data/cv.yaml
@@ -102,7 +102,7 @@ career:
 # Optional:  location, description
 education:
   - year: "2019 – 2024"
-    degree: "PhD — Computer Science"
+    degree: "PhD in Computer Science"
     institution: "Euskal Herriko Unibertsitatea (UPV/EHU)"
     location: "Bilbao, ES"
     description: >
@@ -113,12 +113,12 @@ education:
       - Vicomtech
 
   - year: "2005 – 2008"
-    degree: "MSc — Telecommunications Engineering"
+    degree: "MSc in Telecommunications Engineering"
     institution: "Università degli Studi di Brescia"
     location: "Brescia, IT"
 
   - year: "2000 – 2005"
-    degree: "BSc — Information Technology"
+    degree: "BSc in Information Technology"
     institution: "Università degli Studi di Brescia"
     location: "Brescia, IT"
 
@@ -158,10 +158,10 @@ skills:
     - name: Italian
       proficiency: Native
     - name: Spanish
-      proficiency: "C2 — Proficient"
+      proficiency: "C2: Proficient"
     - name: English
-      proficiency: "C2 — Proficient"
+      proficiency: "C2: Proficient"
     - name: German
-      proficiency: "B2 — Upper-Intermediate"
+      proficiency: "B2: Upper-Intermediate"
     - name: Basque
-      proficiency: "B1 — Intermediate"
+      proficiency: "B1: Intermediate"

--- a/data/projects.js
+++ b/data/projects.js
@@ -42,7 +42,7 @@ export const PROJECTS = [
             year: "2020 – 2022",
             tags: ["Web Application","Co-creation","Social Inclusion"],
             bg: "img/projects/traction-bg.webp",
-            description: "TRACTION was a Horizon 2020 project, coordinated by Vicomtech, that used opera as a vehicle for social inclusion. My work centred on the Co-creation Stage — the real-time distributed performance tool — spanning development, user-requirements gathering, evaluation, and direct engagement with artistic and community partners across Barcelona, Leiria and Ireland.",
+            description: "TRACTION was a Horizon 2020 project, coordinated by Vicomtech, that used opera as a vehicle for social inclusion. My work centred on the Co-creation Stage, the real-time distributed performance tool, spanning development, user-requirements gathering, evaluation, and direct engagement with artistic and community partners across Barcelona, Leiria and Ireland.",
             url: "projects/traction.html",
         },
     {
@@ -96,7 +96,7 @@ export const PROJECTS = [
             year: "2009 – 2014",
             tags: ["Computer Vision","Audio Analysis","Digital Humanities"],
             bg: "img/projects/avatech-bg.webp",
-            description: "AVATecH was a joint Fraunhofer / Max Planck project that brought state-of-the-art audio and video pattern recognition into ELAN — the de-facto annotation tool used by linguists, anthropologists, and psychologists worldwide — turning weeks of manual labelling into minutes of supervised review.",
+            description: "AVATecH was a joint Fraunhofer / Max Planck project that brought state-of-the-art audio and video pattern recognition into ELAN, the de-facto annotation tool used by linguists, anthropologists, and psychologists worldwide, turning weeks of manual labelling into minutes of supervised review.",
             url: "projects/avatech.html",
         }];
 

--- a/index.html
+++ b/index.html
@@ -8,18 +8,18 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://nominatim.openstreetmap.org; media-src 'self'; worker-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; manifest-src 'self'; upgrade-insecure-requests" />
   <!-- /generated:csp-meta -->
   <meta name="description"
-    content="Stefano Masneri — Senior AI Engineer specialising in Machine Learning, Computer Vision, and Augmented Reality. Based in San Sebastián, Spain." />
+    content="Stefano Masneri, Senior AI Engineer specialising in Machine Learning, Computer Vision, and Augmented Reality. Based in San Sebastián, Spain." />
   <meta name="author" content="Stefano Masneri" />
   <meta name="keywords" content="Stefano Masneri, AI Engineer, Machine Learning, Computer Vision, Augmented Reality, Deep Learning, XR, ViT, Speaker Diarisation, San Sebastián" />
   <!-- Disallow AI/LLM training use of this page's content -->
   <meta name="robots" content="index, follow, noai, noimageai" />
-  <title>Stefano Masneri — Machine Learning, Computer Vision &amp; AR</title>
+  <title>Stefano Masneri | Machine Learning, Computer Vision &amp; AR</title>
   <link rel="canonical" href="https://stefanomasneri.com/" />
 
   <!-- Open Graph / Twitter Card -->
   <meta property="og:type"        content="website" />
   <meta property="og:url"         content="https://stefanomasneri.com/" />
-  <meta property="og:title"       content="Stefano Masneri — Machine Learning, Computer Vision &amp; AR" />
+  <meta property="og:title"       content="Stefano Masneri | Machine Learning, Computer Vision &amp; AR" />
   <meta property="og:description" content="Senior AI Engineer specialising in Machine Learning, Computer Vision, and Augmented Reality. Based in San Sebastián, Spain." />
   <meta property="og:image"       content="https://stefanomasneri.com/img/screenshot-hero.png" />
   <meta property="og:image:width"  content="1200" />
@@ -28,7 +28,7 @@
   <meta property="og:locale"      content="en_GB" />
   <meta property="og:site_name"   content="Stefano Masneri" />
   <meta name="twitter:card"        content="summary_large_image" />
-  <meta name="twitter:title"       content="Stefano Masneri — Machine Learning, Computer Vision &amp; AR" />
+  <meta name="twitter:title"       content="Stefano Masneri | Machine Learning, Computer Vision &amp; AR" />
   <meta name="twitter:description" content="Senior AI Engineer specialising in Machine Learning, Computer Vision, and Augmented Reality. Based in San Sebastián, Spain." />
   <meta name="twitter:image"       content="https://stefanomasneri.com/img/screenshot-hero.png" />
   <meta name="twitter:image:alt"   content="Stefano Masneri personal website" />
@@ -230,7 +230,7 @@
             (<a href="docs/defense.pdf" class="inline-link" target="_blank" rel="noopener">defense slides</a>).
           </p>
           <p>
-            I have worked in Italy, Germany, and Spain at both research institutions and software companies — from
+            I have worked in Italy, Germany, and Spain at both research institutions and software companies, from
             start-ups to large consulting firms. Along the way I picked up four foreign languages and a good number
             of programming ones too.
           </p>
@@ -274,7 +274,7 @@
   <section id="research" class="section section-alt" aria-label="Research interests">
     <div class="container">
       <header class="section-header" data-animate>
-        <span class="section-tag">Research</span>
+        <span class="section-tag">Focus</span>
         <h2 class="section-title">What I Work On</h2>
       </header>
       <div class="research-cv-callout" data-animate data-delay="60">
@@ -305,7 +305,7 @@
                 </svg>
               </span>
               <h3 class="card-title">Generative AI &amp; LLMs</h3>
-              <p class="card-desc">Designing and deploying GenAI solutions — from RAG pipelines to fine-tuned models —
+              <p class="card-desc">Designing and deploying GenAI solutions, from RAG pipelines to fine-tuned models,
                 for production use cases in media, banking, and energy.</p>
               <span class="card-flip-hint" aria-hidden="true">click to learn more</span>
             </div>
@@ -353,7 +353,7 @@
               </span>
               <h3 class="card-title">Augmented Reality for Education</h3>
               <p class="card-desc">PhD research on collaborative, multi-user XR experiences that make learning more
-                immersive and effective — from architecture design to large-scale pilots.</p>
+                immersive and effective, from architecture design to large-scale pilots.</p>
               <span class="card-flip-hint" aria-hidden="true">click to learn more</span>
             </div>
             <div class="card-back">
@@ -535,7 +535,7 @@
         <span class="section-tag">Publications</span>
         <h2 class="section-title">Selected Work</h2>
       </header>
-      <p class="publications-intro" data-animate>During my years as a researcher, I published more than 30 articles — the majority of them open access. The papers below represent the core of my PhD work. Use the button below to browse the full list.</p>
+      <p class="publications-intro" data-animate>During my years as a researcher, I published more than 30 articles, the majority of them open access. The papers below represent the core of my PhD work. Use the button below to browse the full list.</p>
       <!-- Items injected by JS — data source: PUBLICATIONS in data/publications.js -->
       <div class="publications-list" id="publications-list" role="list"></div>
       <div class="publications-cta" data-animate>
@@ -553,7 +553,7 @@
       <header class="section-header" data-animate>
         <span class="section-tag">Projects</span>
         <h2 class="section-title">Things I&rsquo;ve Built</h2>
-        <p class="section-subtitle">Here is a random selection of some of my past projects &mdash; refresh the page to see a different set. I am also doing seriously cool stuff at <a href="https://www.mediapro.tv" target="_blank" rel="noopener">Mediapro</a>, but I am not allowed to talk about it just yet.</p>
+        <p class="section-subtitle">Here is a random selection of some of my past projects; refresh the page to see a different set. I am also doing seriously cool stuff at <a href="https://www.mediapro.tv" target="_blank" rel="noopener">Mediapro</a>, but I am not allowed to talk about it just yet.</p>
       </header>
       <!-- Items injected by JS — data source: PROJECTS in data/projects.js -->
       <div class="projects-grid" id="projects-grid"></div>
@@ -568,7 +568,7 @@
           <span class="section-tag">Places</span>
           <h2 class="globe-title">Where I've Been</h2>
           <p class="globe-intro">
-            Travelling is one of my greatest passions — I've been lucky enough to explore many countries
+            Travelling is one of my greatest passions; I've been lucky enough to explore many countries
             around the world, both on work assignments and personal adventures.
           </p>
         </div>
@@ -625,7 +625,7 @@
       <div class="contact-wrap">
         <p class="contact-lead" data-animate>
           Whether you want to collaborate on a research project, discuss AI,
-          or simply say hello — I'm always happy to connect.
+          or simply say hello; I'm always happy to connect.
         </p>
         <!-- Contact cards written directly in HTML; update href/value when details change -->
         <div class="contact-grid" id="contact-grid">

--- a/projects.html
+++ b/projects.html
@@ -8,10 +8,10 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://nominatim.openstreetmap.org; media-src 'self'; worker-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; manifest-src 'self'; upgrade-insecure-requests" />
   <!-- /generated:csp-meta -->
   <meta name="description"
-    content="Projects and portfolio of Stefano Masneri — Senior AI Engineer. AR, Computer Vision, LLMs and more." />
+    content="Projects and portfolio of Stefano Masneri, Senior AI Engineer. AR, Computer Vision, LLMs and more." />
   <meta name="author" content="Stefano Masneri" />
   <meta name="robots" content="index, follow, noai, noimageai" />
-  <title>Projects &amp; Portfolio — Stefano Masneri, AI Engineer</title>
+  <title>Projects &amp; Portfolio | Stefano Masneri, AI Engineer</title>
   <link rel="canonical" href="https://stefanomasneri.com/projects.html" />
 
   <!-- JSON-LD structured data: collection of project case studies. -->
@@ -20,8 +20,8 @@
     "@context": "https://schema.org",
     "@type": "CollectionPage",
     "url": "https://stefanomasneri.com/projects.html",
-    "name": "Projects & Portfolio — Stefano Masneri, AI Engineer",
-    "description": "Projects and portfolio of Stefano Masneri — Senior AI Engineer.",
+    "name": "Projects & Portfolio | Stefano Masneri, AI Engineer",
+    "description": "Projects and portfolio of Stefano Masneri, Senior AI Engineer.",
     "author": {
       "@type": "Person",
       "name": "Stefano Masneri",
@@ -47,7 +47,7 @@
   <!-- Open Graph / Twitter Card -->
   <meta property="og:type"        content="website" />
   <meta property="og:url"         content="https://stefanomasneri.com/projects.html" />
-  <meta property="og:title"       content="Projects &amp; Portfolio — Stefano Masneri, AI Engineer" />
+  <meta property="og:title"       content="Projects &amp; Portfolio | Stefano Masneri, AI Engineer" />
   <meta property="og:description" content="Projects and portfolio of Stefano Masneri, Senior AI Engineer." />
   <meta property="og:image"       content="https://stefanomasneri.com/img/screenshot-hero.png" />
   <meta property="og:image:width"  content="1200" />
@@ -56,7 +56,7 @@
   <meta property="og:locale"      content="en_GB" />
   <meta property="og:site_name"   content="Stefano Masneri" />
   <meta name="twitter:card"        content="summary_large_image" />
-  <meta name="twitter:title"       content="Projects &amp; Portfolio — Stefano Masneri, AI Engineer" />
+  <meta name="twitter:title"       content="Projects &amp; Portfolio | Stefano Masneri, AI Engineer" />
   <meta name="twitter:description" content="Projects and portfolio of Stefano Masneri, Senior AI Engineer." />
   <meta name="twitter:image"       content="https://stefanomasneri.com/img/screenshot-hero.png" />
   <meta name="twitter:image:alt"   content="Stefano Masneri personal website" />

--- a/projects/aroundtheworld.html
+++ b/projects/aroundtheworld.html
@@ -9,21 +9,21 @@
   <meta name="description" content="ARoundTheWorld is a multiplatform collaborative AR geography application built on the cleAR architecture. It was evaluated with 44 students across three schools and represents the final paper of my PhD, validating that the architecture can produce applications that integrate seamlessly into existing school curricula." />
   <meta name="author" content="Stefano Masneri" />
   <meta name="robots" content="index, follow, noai, noimageai" />
-  <title>ARoundTheWorld: Collaborative AR for Education — Stefano Masneri</title>
+  <title>ARoundTheWorld: Collaborative AR for Education | Stefano Masneri</title>
   <link rel="canonical" href="https://stefanomasneri.com/projects/aroundtheworld.html" />
 
   <meta property="og:type"        content="article" />
   <meta property="og:site_name"   content="Stefano Masneri" />
   <meta property="og:locale"      content="en_GB" />
   <meta property="og:url"         content="https://stefanomasneri.com/projects/aroundtheworld.html" />
-  <meta property="og:title"       content="ARoundTheWorld: Collaborative AR for Education — Stefano Masneri" />
+  <meta property="og:title"       content="ARoundTheWorld: Collaborative AR for Education | Stefano Masneri" />
   <meta property="og:description" content="ARoundTheWorld is a multiplatform collaborative AR geography application built on the cleAR architecture. It was evaluated with 44 students across three schools and represents the final paper of my PhD, validating that the architecture can produce applications that integrate seamlessly into existing school curricula." />
   <meta property="og:image"       content="https://stefanomasneri.com/img/projects/ARound_the_world_2.png" />
   <meta property="og:image:width"  content="685" />
   <meta property="og:image:height" content="412" />
   <meta property="og:image:alt"   content="ARoundTheWorld: Collaborative AR for Education" />
   <meta name="twitter:card"        content="summary_large_image" />
-  <meta name="twitter:title"       content="ARoundTheWorld: Collaborative AR for Education — Stefano Masneri" />
+  <meta name="twitter:title"       content="ARoundTheWorld: Collaborative AR for Education | Stefano Masneri" />
   <meta name="twitter:description" content="ARoundTheWorld is a multiplatform collaborative AR geography application built on the cleAR architecture. It was evaluated with 44 students across three schools and represents the final paper of my PhD, validating that the architecture can produce applications that integrate seamlessly into existing school curricula." />
   <meta name="twitter:image"       content="https://stefanomasneri.com/img/projects/ARound_the_world_2.png" />
   <meta name="twitter:image:alt"   content="ARoundTheWorld: Collaborative AR for Education" />
@@ -140,20 +140,20 @@
     <div class="post-lead">ARoundTheWorld is a multiplatform collaborative AR geography application built on the cleAR architecture. It was evaluated with 44 students across three schools and represents the final paper of my PhD, validating that the architecture can produce applications that integrate seamlessly into existing school curricula.</div>
 
     <p>
-ARoundTheWorld is the culmination of my PhD research. Where the <a href="clear-architecture.html">cleAR architecture</a> paper established the infrastructure for building collaborative augmented reality applications in schools, this work demonstrates that infrastructure in a complete, evaluated product — tested with real students in real classrooms. It was published in <em>Virtual Reality</em> (Springer, 2024) and the findings were presented as part of my doctoral thesis defence in March 2024.
+ARoundTheWorld is the culmination of my PhD research. Where the <a href="clear-architecture.html">cleAR architecture</a> paper established the infrastructure for building collaborative augmented reality applications in schools, this work demonstrates that infrastructure in a complete, evaluated product, tested with real students in real classrooms. It was published in <em>Virtual Reality</em> (Springer, 2024) and the findings were presented as part of my doctoral thesis defence in March 2024.
 </p>
 <p>
-The application is a collaborative geography quiz. Once the teacher starts a session, the first student receives a question — for example, <em>&quot;Where is Kyoto?&quot;</em> — and must place a pin on a 3D globe of the Earth rendered in the augmented space. Other students participate in two ways: they can suggest a continent to help the active user, or place a semi-transparent hint marker directly on the globe. The student with the most correct answers wins. The quiz design deliberately mixes individual performance with group collaboration, giving every participant a meaningful role throughout the session.
+The application is a collaborative geography quiz. Once the teacher starts a session, the first student receives a question, for example <em>&quot;Where is Kyoto?&quot;</em>, and must place a pin on a 3D globe of the Earth rendered in the augmented space. Other students participate in two ways: they can suggest a continent to help the active user, or place a semi-transparent hint marker directly on the globe. The student with the most correct answers wins. The quiz design deliberately mixes individual performance with group collaboration, giving every participant a meaningful role throughout the session.
 </p>
 <h2>Implementation</h2>
 <p>
-ARoundTheWorld is built on the design objectives (DOs) defined in the <a href="clear-architecture.html">cleAR architecture</a>. The architecture defines six DOs; for this evaluation, three of them — long-term storage, data visualisation and AI integration — were grouped into a single data-analytics objective, leaving the four below:
+ARoundTheWorld is built on the design objectives (DOs) defined in the <a href="clear-architecture.html">cleAR architecture</a>. The architecture defines six DOs; for this evaluation, three of them, long-term storage, data visualisation and AI integration, were grouped into a single data-analytics objective, leaving the four below:
 </p>
 <ul>
-  <li><strong>DO1 — Interoperability</strong>: the application runs on tablets and smartphones (iOS and Android) as a native AR app, and on laptops and desktops as a browser-based 3D experience, without degrading the collaborative experience.</li>
-  <li><strong>DO2 — Multi-user capabilities</strong>: state is synchronised across all connected devices at 30 updates per second, with end-to-end latency consistently below 15 ms on both Wi-Fi and mobile networks.</li>
-  <li><strong>DO3 — Data analytics</strong>: every student action generates an xAPI statement that is forwarded to a Learning Record Store (LRS) and integrated with the school's LMS, enabling automatic progress tracking without any manual export.</li>
-  <li><strong>DO4 — Ease of development</strong>: the developer noted that the cleAR API handled all networking transparently, eliminating the need to deal with low-level sockets or platform-specific code.</li>
+  <li><strong>DO1: Interoperability</strong>: the application runs on tablets and smartphones (iOS and Android) as a native AR app, and on laptops and desktops as a browser-based 3D experience, without degrading the collaborative experience.</li>
+  <li><strong>DO2: Multi-user capabilities</strong>: state is synchronised across all connected devices at 30 updates per second, with end-to-end latency consistently below 15 ms on both Wi-Fi and mobile networks.</li>
+  <li><strong>DO3: Data analytics</strong>: every student action generates an xAPI statement that is forwarded to a Learning Record Store (LRS) and integrated with the school's LMS, enabling automatic progress tracking without any manual export.</li>
+  <li><strong>DO4: Ease of development</strong>: the developer noted that the cleAR API handled all networking transparently, eliminating the need to deal with low-level sockets or platform-specific code.</li>
 </ul>
 <p>
 A dedicated web interface allows teachers to compose new question sets. Geographical coordinates are resolved automatically via the Wikimedia API and questions are stored as plain JSON files, so new content can be added without touching application code.
@@ -198,13 +198,13 @@ Every question except the first received a positive response (&quot;Agree&quot; 
   <img src="../img/projects/ARound_the_world_4.webp" alt="Mean questionnaire scores with standard deviation" width="2031" height="589" loading="lazy" />
 </figure>
 <p>
-Watchers gave a slightly higher mean score than players, though with greater variability — consistent with being less cognitively loaded during the quiz. Students using Apple devices (iPhone or iPad) rated the application marginally higher than those on Android or PC, but the difference was not statistically significant.
+Watchers gave a slightly higher mean score than players, though with greater variability, consistent with being less cognitively loaded during the quiz. Students using Apple devices (iPhone or iPad) rated the application marginally higher than those on Android or PC, but the difference was not statistically significant.
 </p>
 <figure>
   <img src="../img/projects/ARound_the_world_5.webp" alt="Survey results by device type, student role, and age group" width="2032" height="547" loading="lazy" />
 </figure>
 <p>
-A Pearson correlation analysis between the number of in-app interactions and the questionnaire scores revealed a small but statistically significant positive correlation (<em>p</em> &lt; 0.05): students who engaged more with the collaborative features rated the application more highly. A hierarchical clustering of active-user data in PCA space identified two main groups — one characterised by a high number of interactions and another by higher survey scores — suggesting that engagement and satisfaction, while correlated, capture different aspects of the experience.
+A Pearson correlation analysis between the number of in-app interactions and the questionnaire scores revealed a small but statistically significant positive correlation (<em>p</em> &lt; 0.05): students who engaged more with the collaborative features rated the application more highly. A hierarchical clustering of active-user data in PCA space identified two main groups, one characterised by a high number of interactions and another by higher survey scores, suggesting that engagement and satisfaction, while correlated, capture different aspects of the experience.
 </p>
 <p>
 Post-study teacher interviews confirmed that the collaborative capabilities and the ability to personalise content (creating their own question sets) were the two factors most likely to drive sustained adoption of AR in the classroom.
@@ -214,7 +214,7 @@ Post-study teacher interviews confirmed that the collaborative capabilities and 
 The work was conducted as part of the ARETE project (Augmented Reality Interactive Educational System), funded under the EU Horizon 2020 programme (grant agreement No 856533). The evaluation results show that an application built on the cleAR architecture can fulfil all the design objectives identified by teachers, receive strong approval from students, and integrate into existing school infrastructure with minimal friction.
 </p>
 <p>
-If there is one thing I took from this work, it is that the bottleneck for AR in schools is rarely the technology itself — it is the time teachers don't have to rebuild the same plumbing for every new application. Shared infrastructure that just works lets them focus on teaching instead.
+If there is one thing I took from this work, it is that the bottleneck for AR in schools is rarely the technology itself; it is the time teachers don't have to rebuild the same plumbing for every new application. Shared infrastructure that just works lets them focus on teaching instead.
 </p>
 
       <div class="project-links">

--- a/projects/audience-engagement.html
+++ b/projects/audience-engagement.html
@@ -9,21 +9,21 @@
   <meta name="description" content="A multi-modal system that measures audience engagement at live events by fusing computer vision with WiFi/Bluetooth signal analysis. Designed, implemented, and validated at Vicomtech in 2020, and released as open-source software." />
   <meta name="author" content="Stefano Masneri" />
   <meta name="robots" content="index, follow, noai, noimageai" />
-  <title>Audience Engagement Measurement System — Stefano Masneri</title>
+  <title>Audience Engagement Measurement System | Stefano Masneri</title>
   <link rel="canonical" href="https://stefanomasneri.com/projects/audience-engagement.html" />
 
   <meta property="og:type"        content="article" />
   <meta property="og:site_name"   content="Stefano Masneri" />
   <meta property="og:locale"      content="en_GB" />
   <meta property="og:url"         content="https://stefanomasneri.com/projects/audience-engagement.html" />
-  <meta property="og:title"       content="Audience Engagement Measurement System — Stefano Masneri" />
+  <meta property="og:title"       content="Audience Engagement Measurement System | Stefano Masneri" />
   <meta property="og:description" content="A multi-modal system that measures audience engagement at live events by fusing computer vision with WiFi/Bluetooth signal analysis. Designed, implemented, and validated at Vicomtech in 2020, and released as open-source software." />
   <meta property="og:image"       content="https://stefanomasneri.com/img/projects/audience-engagement-bg.webp" />
   <meta property="og:image:width"  content="1852" />
   <meta property="og:image:height" content="542" />
   <meta property="og:image:alt"   content="Multi-modal Audience Engagement Measurement System" />
   <meta name="twitter:card"        content="summary_large_image" />
-  <meta name="twitter:title"       content="Audience Engagement Measurement System — Stefano Masneri" />
+  <meta name="twitter:title"       content="Audience Engagement Measurement System | Stefano Masneri" />
   <meta name="twitter:description" content="A multi-modal system that measures audience engagement at live events by fusing computer vision with WiFi/Bluetooth signal analysis. Designed, implemented, and validated at Vicomtech in 2020, and released as open-source software." />
   <meta name="twitter:image"       content="https://stefanomasneri.com/img/projects/audience-engagement-bg.webp" />
   <meta name="twitter:image:alt"   content="Multi-modal Audience Engagement Measurement System" />
@@ -143,18 +143,18 @@
 How do you know whether an audience is actually paying attention? For a conference organiser, a museum curator, or a retail-space operator, the question matters: did people show up and engage, or did they walk past? Existing answers relied on either expensive, intrusive sensors or proxy metrics (ticket sales, post-event surveys) that say nothing about what happened in the room.
 </p>
 <p>
-This project, carried out at <strong>Vicomtech</strong> in <strong>2020</strong> and published at <strong>ICAART 2020</strong> (Sanz-Narrillos, Masneri, Zorrilla — <em>&quot;A Multi-modal Audience Engagement Measurement System&quot;</em>), proposed a different answer: combine two cheap, complementary sensing modalities — <strong>computer vision</strong> and <strong>wireless signal strength</strong> — and use each to cover the weaknesses of the other. The complete system was released as open source and is available on <a href="https://github.com/tv-vicomtech/AudienceEngagement" target="_blank" rel="noopener">GitHub</a>.
+This project, carried out at <strong>Vicomtech</strong> in <strong>2020</strong> and published at <strong>ICAART 2020</strong> (Sanz-Narrillos, Masneri, Zorrilla: <em>&quot;A Multi-modal Audience Engagement Measurement System&quot;</em>), proposed a different answer: combine two cheap, complementary sensing modalities, <strong>computer vision</strong> and <strong>wireless signal strength</strong>, and use each to cover the weaknesses of the other. The complete system was released as open source and is available on <a href="https://github.com/tv-vicomtech/AudienceEngagement" target="_blank" rel="noopener">GitHub</a>.
 </p>
 <h2>The Two Modalities</h2>
 <p>
 <strong>Visual channel.</strong> Standard RGB cameras feed a pipeline built on <strong>TensorFlow</strong> and <strong>OpenCV</strong>. For each frame the system runs, in sequence:
 </p>
 <ol>
-  <li>Person detection — locating every individual in the frame.</li>
+  <li>Person detection: locating every individual in the frame.</li>
   <li>Face detection inside each person bounding box.</li>
-  <li>Body-joint estimation — eyes, ears, nose, shoulders, elbows, hands, hips, knees, feet.</li>
+  <li>Body-joint estimation: eyes, ears, nose, shoulders, elbows, hands, hips, knees, feet.</li>
   <li>Frame-to-frame tracking to maintain stable identities over time.</li>
-  <li>Attention-direction estimation based on the geometric configuration of the eyes and nose — classified as <em>front</em>, <em>left</em>, <em>right</em>, or <em>no detection</em>.</li>
+  <li>Attention-direction estimation based on the geometric configuration of the eyes and nose: classified as <em>front</em>, <em>left</em>, <em>right</em>, or <em>no detection</em>.</li>
 </ol>
 <p>
 The visual channel answers rich questions (how many people, where, are they looking at the stage?) but fails in poor lighting, behind obstacles, or when the camera simply does not cover a section of the venue.
@@ -163,17 +163,17 @@ The visual channel answers rich questions (how many people, where, are they look
 <strong>Wireless channel.</strong> A network of <strong>Raspberry Pi scanners</strong> passively listens for WiFi and Bluetooth probe requests from devices in the environment. The received signal strength indicator (RSSI) from each scanner, combined across multiple nodes, is used to estimate the approximate location of each device within a set of predefined zones. The processing is done on a central server using the open-source <strong>Find3</strong> framework; scanners and server communicate via <strong>MQTT (Mosquitto)</strong>.
 </p>
 <p>
-The wireless channel is robust to lighting and occlusions, covers the entire venue regardless of camera placement, and — crucially — provides a <strong>per-device identity</strong> that persists across the event without any cooperation from the attendee.
+The wireless channel is robust to lighting and occlusions, covers the entire venue regardless of camera placement, and, crucially, provides a <strong>per-device identity</strong> that persists across the event without any cooperation from the attendee.
 </p>
 <h2>Fusion</h2>
 <p>
 The two channels cover different things. The visual channel is <em>precise but narrow</em>: it tells you exactly who is looking at what, but only where a camera can see them. The wireless channel is <em>broad but coarse</em>: it knows someone is in the &quot;main hall&quot; zone, but nothing about their pose or attention. The system fuses both to compute, for each zone and each time window:
 </p>
 <ul>
-  <li><strong>Occupancy</strong> — how many distinct devices and people were present.</li>
-  <li><strong>Dwell time</strong> — how long, on average, individuals stayed in the zone.</li>
-  <li><strong>Attention share</strong> — the fraction of visible people whose gaze was directed towards the designated focal point (stage, screen, exhibit).</li>
-  <li><strong>Movement patterns</strong> — total and maximum distance travelled, extracted from the visual tracks.</li>
+  <li><strong>Occupancy</strong>: how many distinct devices and people were present.</li>
+  <li><strong>Dwell time</strong>: how long, on average, individuals stayed in the zone.</li>
+  <li><strong>Attention share</strong>: the fraction of visible people whose gaze was directed towards the designated focal point (stage, screen, exhibit).</li>
+  <li><strong>Movement patterns</strong>: total and maximum distance travelled, extracted from the visual tracks.</li>
 </ul>
 <p>
 An engagement score is computed by weighting these primitives. The weights are not fixed: they can be tuned per venue and per event type, which matters because &quot;engagement&quot; looks very different at a conference talk (low movement, high attention share) than at a museum exhibit (moderate movement, high dwell time) or a product launch (high movement, variable attention).
@@ -183,11 +183,11 @@ An engagement score is computed by weighting these primitives. The weights are n
 The software stack was designed to be deployable on commodity hardware:
 </p>
 <ul>
-  <li><strong>Scanner nodes</strong> — Raspberry Pi 3 / 4 units with wireless monitor-mode dongles, written in <strong>Go</strong> for efficiency on constrained hardware.</li>
-  <li><strong>Server</strong> — Go-based aggregation and inference service, also handling MQTT brokerage.</li>
-  <li><strong>Vision processing</strong> — Python 3 with TensorFlow and OpenCV; runs on a small GPU-equipped edge machine connected to the venue cameras.</li>
-  <li><strong>Messaging</strong> — MQTT over Mosquitto for all inter-component communication.</li>
-  <li><strong>Deployment</strong> — Docker images for each component to simplify installation at the venue.</li>
+  <li><strong>Scanner nodes</strong>: Raspberry Pi 3 / 4 units with wireless monitor-mode dongles, written in <strong>Go</strong> for efficiency on constrained hardware.</li>
+  <li><strong>Server</strong>: Go-based aggregation and inference service, also handling MQTT brokerage.</li>
+  <li><strong>Vision processing</strong>: Python 3 with TensorFlow and OpenCV; runs on a small GPU-equipped edge machine connected to the venue cameras.</li>
+  <li><strong>Messaging</strong>: MQTT over Mosquitto for all inter-component communication.</li>
+  <li><strong>Deployment</strong>: Docker images for each component to simplify installation at the venue.</li>
 </ul>
 <p>
 The deliberate choice of <strong>Go for the wireless side</strong> and <strong>Python for the vision side</strong> reflected practical trade-offs: Go gave us the single-binary deployability and tight memory footprint we needed on the Pi scanners; Python gave us the machine-learning ecosystem for everything visual.
@@ -202,7 +202,7 @@ Three things made this project interesting beyond the engagement-metric angle:
 </p>
 <ol>
   <li><strong>Multi-modal sensor fusion done pragmatically.</strong> Academic papers on multi-modal systems often fuse modalities that share a common machine-learning formulation. Here the channels had completely different statistical properties, completely different hardware requirements, and different failure modes. The fusion had to respect that asymmetry.</li>
-  <li><strong>Open-source release.</strong> The entire stack — scanner firmware, server, vision pipeline, MQTT plumbing, Docker files — is on GitHub and was designed for reproducibility. At the time, very little open tooling existed in the audience-analytics space outside of proprietary, closed commercial offerings.</li>
+  <li><strong>Open-source release.</strong> The entire stack, scanner firmware, server, vision pipeline, MQTT plumbing, Docker files, is on GitHub and was designed for reproducibility. At the time, very little open tooling existed in the audience-analytics space outside of proprietary, closed commercial offerings.</li>
   <li><strong>Privacy-aware by design.</strong> The wireless channel uses <strong>MAC addresses as transient identifiers only</strong>, and all personal identifiers are dropped before aggregation. The visual channel produces only zone-level statistics, not per-person records. This was a deliberate response to the GDPR landscape that was crystallising in Europe in 2019–2020.</li>
 </ol>
 <p>

--- a/projects/avatech.html
+++ b/projects/avatech.html
@@ -6,25 +6,25 @@
   <!-- generated:csp-meta -->
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://nominatim.openstreetmap.org; media-src 'self'; worker-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; manifest-src 'self'; upgrade-insecure-requests" />
   <!-- /generated:csp-meta -->
-  <meta name="description" content="AVATecH was a joint Fraunhofer / Max Planck project that brought state-of-the-art audio and video pattern recognition into ELAN — the de-facto annotation tool used by linguists, anthropologists, and psychologists worldwide — turning weeks of manual labelling into minutes of supervised review." />
+  <meta name="description" content="AVATecH was a joint Fraunhofer / Max Planck project that brought state-of-the-art audio and video pattern recognition into ELAN, the de-facto annotation tool used by linguists, anthropologists, and psychologists worldwide, turning weeks of manual labelling into minutes of supervised review." />
   <meta name="author" content="Stefano Masneri" />
   <meta name="robots" content="index, follow, noai, noimageai" />
-  <title>AVATecH: AI Annotation for Humanities — Stefano Masneri</title>
+  <title>AVATecH: AI Annotation for Humanities | Stefano Masneri</title>
   <link rel="canonical" href="https://stefanomasneri.com/projects/avatech.html" />
 
   <meta property="og:type"        content="article" />
   <meta property="og:site_name"   content="Stefano Masneri" />
   <meta property="og:locale"      content="en_GB" />
   <meta property="og:url"         content="https://stefanomasneri.com/projects/avatech.html" />
-  <meta property="og:title"       content="AVATecH: AI Annotation for Humanities — Stefano Masneri" />
-  <meta property="og:description" content="AVATecH was a joint Fraunhofer / Max Planck project that brought state-of-the-art audio and video pattern recognition into ELAN — the de-facto annotation tool used by linguists, anthropologists, and psychologists worldwide — turning weeks of manual labelling into minutes of supervised review." />
+  <meta property="og:title"       content="AVATecH: AI Annotation for Humanities | Stefano Masneri" />
+  <meta property="og:description" content="AVATecH was a joint Fraunhofer / Max Planck project that brought state-of-the-art audio and video pattern recognition into ELAN, the de-facto annotation tool used by linguists, anthropologists, and psychologists worldwide, turning weeks of manual labelling into minutes of supervised review." />
   <meta property="og:image"       content="https://stefanomasneri.com/img/projects/avatech-bg.webp" />
   <meta property="og:image:width"  content="270" />
   <meta property="og:image:height" content="187" />
   <meta property="og:image:alt"   content="AVATecH: Automated Annotation of Audio/Video Corpora for Humanities Research" />
   <meta name="twitter:card"        content="summary_large_image" />
-  <meta name="twitter:title"       content="AVATecH: AI Annotation for Humanities — Stefano Masneri" />
-  <meta name="twitter:description" content="AVATecH was a joint Fraunhofer / Max Planck project that brought state-of-the-art audio and video pattern recognition into ELAN — the de-facto annotation tool used by linguists, anthropologists, and psychologists worldwide — turning weeks of manual labelling into minutes of supervised review." />
+  <meta name="twitter:title"       content="AVATecH: AI Annotation for Humanities | Stefano Masneri" />
+  <meta name="twitter:description" content="AVATecH was a joint Fraunhofer / Max Planck project that brought state-of-the-art audio and video pattern recognition into ELAN, the de-facto annotation tool used by linguists, anthropologists, and psychologists worldwide, turning weeks of manual labelling into minutes of supervised review." />
   <meta name="twitter:image"       content="https://stefanomasneri.com/img/projects/avatech-bg.webp" />
   <meta name="twitter:image:alt"   content="AVATecH: Automated Annotation of Audio/Video Corpora for Humanities Research" />
 
@@ -71,7 +71,7 @@
     "@context": "https://schema.org",
     "@type": "Article",
     "headline": "AVATecH: AI Annotation for Humanities",
-    "description": "AVATecH was a joint Fraunhofer / Max Planck project that brought state-of-the-art audio and video pattern recognition into ELAN — the de-facto annotation tool used by linguists, anthropologists, and psychologists worldwide — turning weeks of manual labelling into minutes of supervised review.",
+    "description": "AVATecH was a joint Fraunhofer / Max Planck project that brought state-of-the-art audio and video pattern recognition into ELAN, the de-facto annotation tool used by linguists, anthropologists, and psychologists worldwide, turning weeks of manual labelling into minutes of supervised review.",
     "image": "https://stefanomasneri.com/img/projects/avatech-bg.webp",
     "author": {
       "@type": "Person",
@@ -137,7 +137,7 @@
   </header>
 
   <main id="project-content" class="post">
-    <div class="post-lead">AVATecH was a joint Fraunhofer / Max Planck project that brought state-of-the-art audio and video pattern recognition into ELAN — the de-facto annotation tool used by linguists, anthropologists, and psychologists worldwide — turning weeks of manual labelling into minutes of supervised review.</div>
+    <div class="post-lead">AVATecH was a joint Fraunhofer / Max Planck project that brought state-of-the-art audio and video pattern recognition into ELAN, the de-facto annotation tool used by linguists, anthropologists, and psychologists worldwide, turning weeks of manual labelling into minutes of supervised review.</div>
 
     <p>
 AVATecH (<strong>A</strong>udio-<strong>V</strong>isual <strong>T</strong>echnology for <strong>H</strong>umanities Research) was a multi-year research project I worked on at <strong>Fraunhofer Heinrich-Hertz-Institut (HHI)</strong> between <strong>2009 and 2014</strong>, in collaboration with the <strong>Max Planck Institute for Psycholinguistics (MPI Nijmegen)</strong> and <strong>Fraunhofer IAIS</strong>. It was my first major research contribution after joining HHI, and it defined the direction of my early career: applying computer vision and audio analysis to problems outside the traditional media-tech industry.
@@ -146,27 +146,27 @@ AVATecH (<strong>A</strong>udio-<strong>V</strong>isual <strong>T</strong>echnol
 The problem was simple to state and painful to live with. Researchers in linguistics, sign-language studies, child-development psychology, and anthropology depend on annotated audio-visual recordings: transcriptions of speech, boundaries of gestures, phases of interaction, participant labels. Creating those annotations by hand takes between <strong>50 and 100 times the length of the media itself</strong>. A single one-hour field recording could take a PhD student two full weeks to annotate. Corpora of hundreds of hours were common, and every new study needed fresh annotations.
 </p>
 <p>
-AVATecH set out to reduce that burden by automating the most mechanical parts of the annotation pipeline — not to replace the researcher, but to pre-annotate the material so the human expert could focus on correction and semantic judgement rather than clicking through silent segments of video.
+AVATecH set out to reduce that burden by automating the most mechanical parts of the annotation pipeline, not to replace the researcher, but to pre-annotate the material so the human expert could focus on correction and semantic judgement rather than clicking through silent segments of video.
 </p>
 <h2>Approach</h2>
 <p>
-The project produced a suite of <strong>audio and video recognizers</strong> — independent, pluggable modules — that were integrated into <strong>ELAN</strong>, the multi-tier annotation tool developed at MPI and used by thousands of humanities researchers worldwide. ELAN was extended with a generic recognizer API described in XML, so each algorithm could be invoked from inside the tool, run on the loaded media, and return tiers of tentative annotations that the user could accept, edit, or reject.
+The project produced a suite of <strong>audio and video recognizers</strong>, independent, pluggable modules, that were integrated into <strong>ELAN</strong>, the multi-tier annotation tool developed at MPI and used by thousands of humanities researchers worldwide. ELAN was extended with a generic recognizer API described in XML, so each algorithm could be invoked from inside the tool, run on the loaded media, and return tiers of tentative annotations that the user could accept, edit, or reject.
 </p>
 <p>
 Among the recognizers delivered:
 </p>
 <ul>
-  <li><strong>Shot-boundary detection</strong> — segmenting raw video into visually coherent units, essential for any downstream analysis of filmed interviews or field recordings.</li>
-  <li><strong>Speech activity detection</strong> — fine-grained segmentation of audio into speech / non-speech regions, independent of language. Critical for field recordings where languages may be under-documented and no speech-recognition model exists.</li>
-  <li><strong>Speaker clustering</strong> — grouping speech segments by speaker identity without prior enrollment, so researchers studying turn-taking or dialogue structure could start from automatic speaker diarization.</li>
-  <li><strong>Lecture and conference video segmentation</strong> — SVM-based structuring of long-form educational recordings, published separately at VISAPP 2014.</li>
+  <li><strong>Shot-boundary detection</strong>: segmenting raw video into visually coherent units, essential for any downstream analysis of filmed interviews or field recordings.</li>
+  <li><strong>Speech activity detection</strong>: fine-grained segmentation of audio into speech / non-speech regions, independent of language. Critical for field recordings where languages may be under-documented and no speech-recognition model exists.</li>
+  <li><strong>Speaker clustering</strong>: grouping speech segments by speaker identity without prior enrollment, so researchers studying turn-taking or dialogue structure could start from automatic speaker diarization.</li>
+  <li><strong>Lecture and conference video segmentation</strong>: SVM-based structuring of long-form educational recordings, published separately at VISAPP 2014.</li>
 </ul>
 <p>
 The recognizers were designed as <strong>modular components with adaptation and feedback mechanisms</strong>: the researcher's corrections could be fed back into the models, allowing them to adapt to the often unusual acoustic and visual conditions of humanities field data (low-quality recordings, overlapping speech, non-standard camera placements).
 </p>
 <h2>Technical Context</h2>
 <p>
-The project ran during a period in which audio and video analysis was transitioning from hand-crafted features to learned representations — pre-deep-learning era. The speech and speaker modules relied on MFCC features, GMM/HMM acoustic models, and clustering algorithms; the video modules used colour histograms, motion vectors, and SVM classifiers. Every recognizer had to run acceptably fast on a standard researcher laptop — no GPUs, no cloud.
+The project ran during a period in which audio and video analysis was transitioning from hand-crafted features to learned representations, pre-deep-learning era. The speech and speaker modules relied on MFCC features, GMM/HMM acoustic models, and clustering algorithms; the video modules used colour histograms, motion vectors, and SVM classifiers. Every recognizer had to run acceptably fast on a standard researcher laptop; no GPUs, no cloud.
 </p>
 <p>
 Making all of that <strong>integrate cleanly into a tool users already knew and trusted</strong> was as much of the work as the algorithms themselves. ELAN had an established user base and a very specific interaction model; any pre-annotations had to slot into that model without disrupting existing workflows.
@@ -176,17 +176,17 @@ Making all of that <strong>integrate cleanly into a tool users already knew and 
 The work produced several peer-reviewed papers, including:
 </p>
 <ul>
-  <li><em>AVATecH: Audio/Video Technology for Humanities Research</em> — LREC Workshop on Language Technologies for Digital Humanities, Hissar, Bulgaria, <strong>2011</strong>.</li>
-  <li><em>AVATecH — Automated Annotation Through Audio and Video Analysis</em> — LREC 2012, Istanbul.</li>
-  <li><em>Application of Audio and Video Processing Methods for Language Research and Documentation: The AVATecH Project</em> — book chapter in <em>Human Language Technology Challenges for Computer Science and Linguistics</em>, Springer, <strong>2014</strong>.</li>
-  <li><em>SVM-based Video Segmentation and Annotation of Lectures and Conferences</em> — VISAPP <strong>2014</strong>.</li>
+  <li><em>AVATecH: Audio/Video Technology for Humanities Research</em>: LREC Workshop on Language Technologies for Digital Humanities, Hissar, Bulgaria, <strong>2011</strong>.</li>
+  <li><em>AVATecH: Automated Annotation Through Audio and Video Analysis</em>: LREC 2012, Istanbul.</li>
+  <li><em>Application of Audio and Video Processing Methods for Language Research and Documentation: The AVATecH Project</em>: book chapter in <em>Human Language Technology Challenges for Computer Science and Linguistics</em>, Springer, <strong>2014</strong>.</li>
+  <li><em>SVM-based Video Segmentation and Annotation of Lectures and Conferences</em>: VISAPP <strong>2014</strong>.</li>
 </ul>
 <p>
 The recognizers shipped as part of <strong>ELAN</strong> and remained part of the tool's standard distribution for years. For a young engineer, seeing work that started as algorithm research end up in the daily workflow of humanities researchers in dozens of institutions was a lasting lesson: <strong>the technical contribution matters only as much as its path into the hands of the people who need it</strong>.
 </p>
 <h2>Personal Reflection</h2>
 <p>
-AVATecH shaped my approach to every project that followed. The constraints of the problem — messy real-world data, domain experts who are not programmers, a tool ecosystem that already exists, evaluation metrics that must reflect real usefulness rather than benchmark performance — are the same constraints I have met again and again, in AR for education and later in GenAI for enterprise. The specific algorithms have aged (a modern version of almost every recognizer would be built on transformer-based models in a tenth of the code), but the engineering discipline of the project has not.
+AVATecH shaped my approach to every project that followed. The constraints of the problem, messy real-world data, domain experts who are not programmers, a tool ecosystem that already exists, evaluation metrics that must reflect real usefulness rather than benchmark performance, are the same constraints I have met again and again, in AR for education and later in GenAI for enterprise. The specific algorithms have aged (a modern version of almost every recognizer would be built on transformer-based models in a tenth of the code), but the engineering discipline of the project has not.
 </p>
 
       <div class="project-links">

--- a/projects/clear-architecture.html
+++ b/projects/clear-architecture.html
@@ -11,14 +11,14 @@
     content="cleAR is a modular, interoperable architecture for building multi-user augmented reality applications in education. Designed from the ground up to bridge the gap between AR's potential and its limited classroom adoption, it was the core contribution of my PhD research." />
   <meta name="author" content="Stefano Masneri" />
   <meta name="robots" content="index, follow, noai, noimageai" />
-  <title>cleAR: Architecture for Multi-User AR — Stefano Masneri</title>
+  <title>cleAR: Architecture for Multi-User AR | Stefano Masneri</title>
   <link rel="canonical" href="https://stefanomasneri.com/projects/clear-architecture.html" />
 
   <meta property="og:type" content="article" />
   <meta property="og:site_name"   content="Stefano Masneri" />
   <meta property="og:locale"      content="en_GB" />
   <meta property="og:url" content="https://stefanomasneri.com/projects/clear-architecture.html" />
-  <meta property="og:title" content="cleAR: Architecture for Multi-User AR — Stefano Masneri" />
+  <meta property="og:title" content="cleAR: Architecture for Multi-User AR | Stefano Masneri" />
   <meta property="og:description"
     content="cleAR is a modular, interoperable architecture for building multi-user augmented reality applications in education. Designed from the ground up to bridge the gap between AR's potential and its limited classroom adoption, it was the core contribution of my PhD research." />
   <meta property="og:image" content="https://stefanomasneri.com/img/projects/clear-architecture.webp" />
@@ -26,7 +26,7 @@
   <meta property="og:image:height" content="405" />
   <meta property="og:image:alt"   content="cleAR: Interoperable Architecture for Multi-User AR" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="cleAR: Architecture for Multi-User AR — Stefano Masneri" />
+  <meta name="twitter:title" content="cleAR: Architecture for Multi-User AR | Stefano Masneri" />
   <meta name="twitter:description"
     content="cleAR is a modular, interoperable architecture for building multi-user augmented reality applications in education. Designed from the ground up to bridge the gap between AR's potential and its limited classroom adoption, it was the core contribution of my PhD research." />
   <meta name="twitter:image"       content="https://stefanomasneri.com/img/projects/clear-architecture.webp" />
@@ -155,8 +155,8 @@
       published in the <em>Virtual Reality</em> journal (Springer, 2023).
     </p>
     <p>
-      Despite the well-documented benefits of AR in learning — improved motivation, better concept assimilation, easier
-      knowledge transfer — its adoption in classrooms remains remarkably limited. Two barriers stand out: the difficulty
+      Despite the well-documented benefits of AR in learning, improved motivation, better concept assimilation, easier
+      knowledge transfer, its adoption in classrooms remains remarkably limited. Two barriers stand out: the difficulty
       of implementing collaborative, multi-user scenarios and the challenge of integrating AR tools into existing school
       infrastructure and curricula. cleAR was designed to address both.
     </p>
@@ -169,18 +169,18 @@
       <img src="../img/projects/clear-design-objectives.webp" alt="Design objectives diagram" width="751" height="469" loading="lazy" />
     </figure>
     <ul>
-      <li><strong>DO1 — Interoperability</strong>: Cross-platform support for head-mounted displays, tablets,
+      <li><strong>DO1: Interoperability</strong>: Cross-platform support for head-mounted displays, tablets,
         smartphones, and browsers, as well as compatibility with existing AR frameworks and learning management systems.
       </li>
-      <li><strong>DO2 — Multi-user interactions</strong>: Real-time collaboration between students and teachers, both
+      <li><strong>DO2: Multi-user interactions</strong>: Real-time collaboration between students and teachers, both
         in-person and remotely.</li>
-      <li><strong>DO3 — Long-term storage</strong>: Persistent capture of student progress, task completion, and
+      <li><strong>DO3: Long-term storage</strong>: Persistent capture of student progress, task completion, and
         interaction data for longitudinal analysis.</li>
-      <li><strong>DO4 — Data visualisation</strong>: Automatic generation of reports and interactive dashboards
+      <li><strong>DO4: Data visualisation</strong>: Automatic generation of reports and interactive dashboards
         accessible to teachers without programming skills.</li>
-      <li><strong>DO5 — AI integration</strong>: Support for machine learning pipelines that can surface usage patterns,
+      <li><strong>DO5: AI integration</strong>: Support for machine learning pipelines that can surface usage patterns,
         estimate task difficulty, and flag students at risk of falling behind.</li>
-      <li><strong>DO6 — Ease of development</strong>: A clean, well-documented API surface so developers can build new
+      <li><strong>DO6: Ease of development</strong>: A clean, well-documented API surface so developers can build new
         AR experiences without reimplementing common infrastructure.</li>
     </ul>
     <h2>Architecture</h2>
@@ -219,7 +219,7 @@
       Three proof-of-concept applications were developed to validate the architecture against the design objectives.
     </p>
     <p>
-      <strong>AR Cube</strong> — a minimal multi-user app in which up to four users share a virtual cube and can
+      <strong>AR Cube</strong>: a minimal multi-user app in which up to four users share a virtual cube and can
       manipulate its rotation and colour in real time across iOS, Android, Windows, and Linux. The core collaborative
       logic required fewer than 400 lines of code, demonstrating DO6. Average end-to-end latency was 205 ms on both
       Wi-Fi and 4G.
@@ -228,13 +228,13 @@
       <img src="../img/projects/clear-ar-cube.webp" alt="AR Cube proof-of-concept" width="551" height="310" loading="lazy" />
     </figure>
     <p>
-      <strong>xAPI Data Analysis</strong> — a stress-test scenario generating ~80,000 xAPI statements from 10 concurrent
+      <strong>xAPI Data Analysis</strong>: a stress-test scenario generating ~80,000 xAPI statements from 10 concurrent
       clients, stored in MongoDB via Learning Locker on AWS. Average processing delay was 145 ms (maximum 314 ms). A
       classification model trained on the collected data successfully predicted the originating client from the xAPI
       triplet, validating DO3–DO5.
     </p>
     <p>
-      <strong>AR Geography Quiz</strong> — the most complete proof-of-concept, placing a teacher and multiple students
+      <strong>AR Geography Quiz</strong>: the most complete proof-of-concept, placing a teacher and multiple students
       around a shared 3D Earth model. Students can explore individually or switch to a synchronised shared-perspective
       mode where the teacher controls the view and sends targeted questions. The application runs on both desktop and
       mobile (Android/iOS) and demonstrates the full cleAR stack end-to-end.

--- a/projects/mlops-vertex-media.html
+++ b/projects/mlops-vertex-media.html
@@ -9,21 +9,21 @@
   <meta name="description" content="End-to-end MLOps platform built on Google Cloud for one of the largest media companies in Spain. Took a portfolio of disconnected ML models: churn prediction, article recommendation and several others, and rebuilt them as Vertex AI pipelines with versioning, monitoring, drift detection and CI/CD across the whole lifecycle." />
   <meta name="author" content="Stefano Masneri" />
   <meta name="robots" content="index, follow, noai, noimageai" />
-  <title>MLOps Platform on GCP for a Spanish Media Group — Stefano Masneri</title>
+  <title>MLOps Platform on GCP for a Spanish Media Group | Stefano Masneri</title>
   <link rel="canonical" href="https://stefanomasneri.com/projects/mlops-vertex-media.html" />
 
   <meta property="og:type"        content="article" />
   <meta property="og:site_name"   content="Stefano Masneri" />
   <meta property="og:locale"      content="en_GB" />
   <meta property="og:url"         content="https://stefanomasneri.com/projects/mlops-vertex-media.html" />
-  <meta property="og:title"       content="MLOps Platform on GCP for a Spanish Media Group — Stefano Masneri" />
+  <meta property="og:title"       content="MLOps Platform on GCP for a Spanish Media Group | Stefano Masneri" />
   <meta property="og:description" content="End-to-end MLOps platform built on Google Cloud for one of the largest media companies in Spain. Took a portfolio of disconnected ML models: churn prediction, article recommendation and several others, and rebuilt them as Vertex AI pipelines with versioning, monitoring, drift detection and CI/CD across the whole lifecycle." />
   <meta property="og:image"       content="https://stefanomasneri.com/img/projects/mlops-bg.webp" />
   <meta property="og:image:width"  content="1600" />
   <meta property="og:image:height" content="840" />
   <meta property="og:image:alt"   content="MLOps Platform on GCP for a Spanish Media Group" />
   <meta name="twitter:card"        content="summary_large_image" />
-  <meta name="twitter:title"       content="MLOps Platform on GCP for a Spanish Media Group — Stefano Masneri" />
+  <meta name="twitter:title"       content="MLOps Platform on GCP for a Spanish Media Group | Stefano Masneri" />
   <meta name="twitter:description" content="End-to-end MLOps platform built on Google Cloud for one of the largest media companies in Spain. Took a portfolio of disconnected ML models: churn prediction, article recommendation and several others, and rebuilt them as Vertex AI pipelines with versioning, monitoring, drift detection and CI/CD across the whole lifecycle." />
   <meta name="twitter:image"       content="https://stefanomasneri.com/img/projects/mlops-bg.webp" />
   <meta name="twitter:image:alt"   content="MLOps Platform on GCP for a Spanish Media Group" />
@@ -172,10 +172,10 @@ We designed the platform around the standard MLOps lifecycle: data, training, re
   <img src="../img/projects/mlops-architecture.webp" alt="MLOps architecture on GCP" width="1408" height="768" loading="lazy" />
 </figure>
 <p>
-<strong>Data layer.</strong> All training and serving data flows through <strong>BigQuery</strong>, with Dataflow handling the batch and streaming ETL feeding it. Curated feature tables are published to the <strong>Vertex AI Feature Store</strong> so the same definitions can serve both training and online inference — closing the most common source of training/serving skew. Raw artefacts and dataset snapshots are stored in <strong>GCS</strong> with object versioning enabled, so any pipeline run can be replayed against the exact data it originally consumed.
+<strong>Data layer.</strong> All training and serving data flows through <strong>BigQuery</strong>, with Dataflow handling the batch and streaming ETL feeding it. Curated feature tables are published to the <strong>Vertex AI Feature Store</strong> so the same definitions can serve both training and online inference, closing the most common source of training/serving skew. Raw artefacts and dataset snapshots are stored in <strong>GCS</strong> with object versioning enabled, so any pipeline run can be replayed against the exact data it originally consumed.
 </p>
 <p>
-<strong>Training and registry.</strong> Models are trained inside <strong>Vertex AI Pipelines</strong> using the Kubeflow Pipelines (KFP) SDK. Each pipeline is a DAG of containerised steps — ingest, validate, build features, train, evaluate, register — and steps are reusable across models so a new project starts from a working skeleton rather than a blank notebook. <strong>Vertex AI Experiments</strong> captures every run's parameters, metrics and lineage; the trained binaries land in the <strong>Vertex AI Model Registry</strong>, where they are versioned, tagged with their evaluation metrics, and promoted through staging aliases (<code>candidate</code> → <code>staging</code> → <code>production</code>) under explicit approval gates.
+<strong>Training and registry.</strong> Models are trained inside <strong>Vertex AI Pipelines</strong> using the Kubeflow Pipelines (KFP) SDK. Each pipeline is a DAG of containerised steps, ingest, validate, build features, train, evaluate, register, and steps are reusable across models so a new project starts from a working skeleton rather than a blank notebook. <strong>Vertex AI Experiments</strong> captures every run's parameters, metrics and lineage; the trained binaries land in the <strong>Vertex AI Model Registry</strong>, where they are versioned, tagged with their evaluation metrics, and promoted through staging aliases (<code>candidate</code> → <code>staging</code> → <code>production</code>) under explicit approval gates.
 </p>
 <p>
 <strong>Serving.</strong> The recommender and a handful of low-latency models are served as <strong>Vertex AI Endpoints</strong> with canary deployments and traffic splitting; the churn predictor and other batch-oriented models run as scheduled <strong>Vertex AI Batch Prediction</strong> jobs that write their outputs back to BigQuery for the downstream CRM and marketing systems.
@@ -184,11 +184,11 @@ We designed the platform around the standard MLOps lifecycle: data, training, re
 <strong>Monitoring.</strong> Every production endpoint is wired into <strong>Vertex AI Model Monitoring</strong>, which compares the live feature distribution against the training baseline and raises alerts when feature drift, prediction drift or training/serving skew cross a threshold. Alerts flow into the same Cloud Logging / Cloud Monitoring stack the rest of the platform uses, so the on-call rotation sees model issues alongside infrastructure issues.
 </p>
 <p>
-<strong>Cross-cutting concerns.</strong> <strong>Cloud Build</strong> runs CI/CD on every commit — unit tests, integration tests, container builds, pipeline submissions in dev — and <strong>Terraform</strong> describes all the GCP resources so environments (dev, staging, prod) are not snowflakes. <strong>Cloud Scheduler</strong> triggers the periodic retraining and batch-scoring runs. <strong>IAM</strong> and <strong>KMS</strong> handle access control and secrets uniformly across the platform.
+<strong>Cross-cutting concerns.</strong> <strong>Cloud Build</strong> runs CI/CD on every commit, unit tests, integration tests, container builds, pipeline submissions in dev, and <strong>Terraform</strong> describes all the GCP resources so environments (dev, staging, prod) are not snowflakes. <strong>Cloud Scheduler</strong> triggers the periodic retraining and batch-scoring runs. <strong>IAM</strong> and <strong>KMS</strong> handle access control and secrets uniformly across the platform.
 </p>
 <h2>What a Pipeline Actually Does</h2>
 <p>
-Each model — churn, recommender, the rest — ended up as a Vertex AI Pipeline with broadly the same shape. The specifics differ (the recommender has a much larger training step and runs less often; the churn predictor scores in batch overnight) but the structure is shared.
+Each model, churn, recommender, the rest, ended up as a Vertex AI Pipeline with broadly the same shape. The specifics differ (the recommender has a much larger training step and runs less often; the churn predictor scores in batch overnight) but the structure is shared.
 </p>
 <figure>
   <img src="../img/projects/mlops-pipeline.webp" alt="Vertex AI pipeline run" width="1408" height="768" loading="lazy" />
@@ -197,13 +197,13 @@ Each model — churn, recommender, the rest — ended up as a Vertex AI Pipeline
 The pipeline runs on a schedule (typically weekly for churn, daily for the recommender) or whenever Model Monitoring raises a drift alert against the corresponding production endpoint. A typical run goes through:
 </p>
 <ol>
-  <li><strong>Ingest</strong> — a parameterised BigQuery query produces a dated training snapshot and writes it to GCS. The snapshot URI is recorded as a pipeline parameter so the run is fully reproducible.</li>
-  <li><strong>Validate</strong> — schema, types and basic statistics are checked against the previous snapshot. Anything that looks wrong (a feature distribution that has shifted suspiciously, a column that has gone missing) fails the pipeline early before any compute is wasted on training.</li>
-  <li><strong>Features</strong> — transformations and joins produce the model-ready feature set, which is materialised in the Feature Store so the same definitions are available at inference time.</li>
-  <li><strong>Train</strong> — the model is trained inside a custom container, optionally with hyperparameter tuning when the training budget allows it.</li>
-  <li><strong>Evaluate</strong> — offline metrics are computed and compared against the current production model. Both the new candidate's metrics and the comparison are logged to Experiments.</li>
-  <li><strong>Register</strong> — if the candidate is at least as good as production on the agreed metrics, it is registered in the Model Registry and tagged as a candidate. If not, the run halts and an alert is raised — no silent regressions.</li>
-  <li><strong>Deploy</strong> — a candidate that passes the offline gate is rolled out to a canary endpoint with a small slice of live traffic, monitored for a defined window, and either promoted to take 100% of traffic or rolled back automatically.</li>
+  <li><strong>Ingest</strong>: a parameterised BigQuery query produces a dated training snapshot and writes it to GCS. The snapshot URI is recorded as a pipeline parameter so the run is fully reproducible.</li>
+  <li><strong>Validate</strong>: schema, types and basic statistics are checked against the previous snapshot. Anything that looks wrong (a feature distribution that has shifted suspiciously, a column that has gone missing) fails the pipeline early before any compute is wasted on training.</li>
+  <li><strong>Features</strong>: transformations and joins produce the model-ready feature set, which is materialised in the Feature Store so the same definitions are available at inference time.</li>
+  <li><strong>Train</strong>: the model is trained inside a custom container, optionally with hyperparameter tuning when the training budget allows it.</li>
+  <li><strong>Evaluate</strong>: offline metrics are computed and compared against the current production model. Both the new candidate's metrics and the comparison are logged to Experiments.</li>
+  <li><strong>Register</strong>: if the candidate is at least as good as production on the agreed metrics, it is registered in the Model Registry and tagged as a candidate. If not, the run halts and an alert is raised; no silent regressions.</li>
+  <li><strong>Deploy</strong>: a candidate that passes the offline gate is rolled out to a canary endpoint with a small slice of live traffic, monitored for a defined window, and either promoted to take 100% of traffic or rolled back automatically.</li>
 </ol>
 <p>
 The full cycle runs without human intervention on the happy path; the human work is concentrated where it actually adds value: reviewing the model card before promotion, investigating drift alerts, deciding whether a borderline candidate is worth shipping.
@@ -229,7 +229,7 @@ By the end of the engagement, all the models in scope were running on Vertex AI 
 <ul>
   <li>Retraining went from a manual, days-long process per model to a scheduled pipeline run measured in hours.</li>
   <li>Promoting a new model version went from copying files to opening a pull request and approving the candidate in the Model Registry.</li>
-  <li>Drift detection that previously did not exist now caught two distinct feature-distribution shifts on the recommender during the first months of operation — one of them traced back to an upstream change in how article tags were generated, which would otherwise have quietly degraded recommendations.</li>
+  <li>Drift detection that previously did not exist now caught two distinct feature-distribution shifts on the recommender during the first months of operation; one of them traced back to an upstream change in how article tags were generated, which would otherwise have quietly degraded recommendations.</li>
   <li>Onboarding a new model became a question of cloning a pipeline template and filling in the model-specific bits, rather than designing the operational story from scratch.</li>
 </ul>
 <p>

--- a/projects/mpi-brain-research.html
+++ b/projects/mpi-brain-research.html
@@ -9,21 +9,21 @@
   <meta name="description" content="Two years as a scientific software developer in Gilles Laurent's department at the Max Planck Institute for Brain Research in Frankfurt, building MATLAB analysis pipelines and R/Shiny web apps for electrophysiologists studying sleep in bearded dragons and visual processing in ex-vivo turtle brains." />
   <meta name="author" content="Stefano Masneri" />
   <meta name="robots" content="index, follow, noai, noimageai" />
-  <title>Reptilian Neuroscience Software at MPI — Stefano Masneri</title>
+  <title>Reptilian Neuroscience Software at MPI | Stefano Masneri</title>
   <link rel="canonical" href="https://stefanomasneri.com/projects/mpi-brain-research.html" />
 
   <meta property="og:type"        content="article" />
   <meta property="og:site_name"   content="Stefano Masneri" />
   <meta property="og:locale"      content="en_GB" />
   <meta property="og:url"         content="https://stefanomasneri.com/projects/mpi-brain-research.html" />
-  <meta property="og:title"       content="Reptilian Neuroscience Software at MPI — Stefano Masneri" />
+  <meta property="og:title"       content="Reptilian Neuroscience Software at MPI | Stefano Masneri" />
   <meta property="og:description" content="Two years as a scientific software developer in Gilles Laurent's department at the Max Planck Institute for Brain Research in Frankfurt, building MATLAB analysis pipelines and R/Shiny web apps for electrophysiologists studying sleep in bearded dragons and visual processing in ex-vivo turtle brains." />
   <meta property="og:image"       content="https://stefanomasneri.com/img/projects/mpi-brain-bg.webp" />
   <meta property="og:image:width"  content="292" />
   <meta property="og:image:height" content="173" />
   <meta property="og:image:alt"   content="MPI for Brain Research: Software for Reptilian Neuroscience" />
   <meta name="twitter:card"        content="summary_large_image" />
-  <meta name="twitter:title"       content="Reptilian Neuroscience Software at MPI — Stefano Masneri" />
+  <meta name="twitter:title"       content="Reptilian Neuroscience Software at MPI | Stefano Masneri" />
   <meta name="twitter:description" content="Two years as a scientific software developer in Gilles Laurent's department at the Max Planck Institute for Brain Research in Frankfurt, building MATLAB analysis pipelines and R/Shiny web apps for electrophysiologists studying sleep in bearded dragons and visual processing in ex-vivo turtle brains." />
   <meta name="twitter:image"       content="https://stefanomasneri.com/img/projects/mpi-brain-bg.webp" />
   <meta name="twitter:image:alt"   content="MPI for Brain Research: Software for Reptilian Neuroscience" />
@@ -143,27 +143,27 @@
 Between <strong>2015 and 2017</strong> I worked as a <strong>Scientific Software Developer</strong> at the <strong>Max Planck Institute for Brain Research</strong> in Frankfurt, in the department led by <strong>Prof. Gilles Laurent</strong>. I want to be precise about my role from the start: I was <strong>not a researcher</strong> there. I did not run experiments, design studies, or co-author the papers that came out of the lab. I was the engineer who sat next to the people doing all of that, and helped them turn their data into something they could actually look at.
 </p>
 <p>
-What made the place extraordinary was the science the researchers were doing around me. The Laurent lab studies the function and dynamics of neuronal circuits, with a particular interest in <strong>non-mammalian vertebrates</strong> — reptiles and cephalopods — as windows into the deep evolutionary origins of the brain. In the two years I was there, I had a front-row seat to two projects that I still describe to people whenever the conversation turns to &quot;the most interesting thing you've ever worked on&quot;.
+What made the place extraordinary was the science the researchers were doing around me. The Laurent lab studies the function and dynamics of neuronal circuits, with a particular interest in <strong>non-mammalian vertebrates</strong>, reptiles and cephalopods, as windows into the deep evolutionary origins of the brain. In the two years I was there, I had a front-row seat to two projects that I still describe to people whenever the conversation turns to &quot;the most interesting thing you've ever worked on&quot;.
 </p>
 <h2>Sleep in Bearded Dragons</h2>
 <p>
-The first was the Pogona sleep work. <em>Pogona vitticeps</em>, the <strong>Australian central bearded dragon</strong>, was the unlikely star of the lab. For decades, the textbook story had been that the two sleep states familiar to us — <strong>slow-wave sleep</strong> and <strong>REM sleep</strong> — were a mammalian (and avian) invention. Reptiles slept, but they did not have those characteristic alternating brain rhythms. Or so it was thought.
+The first was the Pogona sleep work. <em>Pogona vitticeps</em>, the <strong>Australian central bearded dragon</strong>, was the unlikely star of the lab. For decades, the textbook story had been that the two sleep states familiar to us, <strong>slow-wave sleep</strong> and <strong>REM sleep</strong>, were a mammalian (and avian) invention. Reptiles slept, but they did not have those characteristic alternating brain rhythms. Or so it was thought.
 </p>
 <p>
 To test this properly, the experimental team needed long, continuous, high-quality recordings from the brains of awake and sleeping animals. The setup was very cool and straight from science fiction (at least for me): the dragons were fitted with what we called <strong>&quot;the hat&quot;</strong>: a small custom-built headstage cemented to the skull, from which thin cables emerged carrying signals from <strong>silicon probes implanted deep in the brain</strong> (in the dorsal ventricular ridge, the reptilian analogue of cortex). The animals lived their normal lives in their tanks while the system recorded <strong>for weeks at a time</strong>, capturing every nap, every overnight sleep cycle, every transition between states.
 </p>
 <p>
-The signals revealed two regular oscillating brain states alternating with a period of roughly <strong>80 seconds</strong>, repeating for <strong>6 to 10 hours every night</strong> — the reptilian equivalents of slow-wave and REM sleep. The paper, <em>&quot;Slow waves, sharp waves, ripples, and REM in sleeping dragons&quot;</em>, appeared in <strong>Science</strong> in 2016 and pushed the likely evolutionary origin of these sleep dynamics back at least to the common amniote ancestor of mammals, birds, and reptiles, more than 300 million years ago.
+The signals revealed two regular oscillating brain states alternating with a period of roughly <strong>80 seconds</strong>, repeating for <strong>6 to 10 hours every night</strong>, the reptilian equivalents of slow-wave and REM sleep. The paper, <em>&quot;Slow waves, sharp waves, ripples, and REM in sleeping dragons&quot;</em>, appeared in <strong>Science</strong> in 2016 and pushed the likely evolutionary origin of these sleep dynamics back at least to the common amniote ancestor of mammals, birds, and reptiles, more than 300 million years ago.
 </p>
 <h2>Moving Images in a Turtle Brain on a Slide</h2>
 <p>
 The second project was, if anything, even stranger. The lab also worked on the <strong>visual cortex of the turtle</strong>. Turtle brain tissue has an unusual property that makes it priceless to neuroscientists: <strong>it remains alive and electrophysiologically active for days after the animal is sacrificed</strong>, kept in oxygenated artificial cerebrospinal fluid. This is much harder to do with mammalian tissue, which deteriorates quickly.
 </p>
 <p>
-The researchers exploited this to build something that on first hearing sounds vaguely science-fiction. They prepared <strong>whole isolated turtle brains, with the eyes still attached via the optic nerve</strong>, in a recording chamber. They then <strong>showed moving visual stimuli to the eyes of the disembodied preparation</strong> — drifting bars, gratings, natural scenes — and recorded from the cortex as the visual signals propagated in. In other preparations they worked with brain slices in which the visual cortex was still wired up enough to respond to direct stimulation.
+The researchers exploited this to build something that on first hearing sounds vaguely science-fiction. They prepared <strong>whole isolated turtle brains, with the eyes still attached via the optic nerve</strong>, in a recording chamber. They then <strong>showed moving visual stimuli to the eyes of the disembodied preparation</strong>, drifting bars, gratings, natural scenes, and recorded from the cortex as the visual signals propagated in. In other preparations they worked with brain slices in which the visual cortex was still wired up enough to respond to direct stimulation.
 </p>
 <p>
-The headline result is in the paper <em>&quot;Spatial Information in a Non-retinotopic Visual Cortex&quot;</em> (Fournier, Müller, Schneider, Hemberger, and Laurent, <em>Neuron</em>, 2018), based on data collected in the period I was there. It showed that the turtle visual cortex represents space in a way that is <strong>not retinotopic</strong> — neighbouring points in the visual field are not represented by neighbouring neurons, in contrast to mammalian primary visual cortex. Instead, spatial information is distributed across the cortex in a more mixed, sequence-like fashion. It is one of those findings that quietly destabilises the neat picture in the textbooks.
+The headline result is in the paper <em>&quot;Spatial Information in a Non-retinotopic Visual Cortex&quot;</em> (Fournier, Müller, Schneider, Hemberger, and Laurent, <em>Neuron</em>, 2018), based on data collected in the period I was there. It showed that the turtle visual cortex represents space in a way that is <strong>not retinotopic</strong>; neighbouring points in the visual field are not represented by neighbouring neurons, in contrast to mammalian primary visual cortex. Instead, spatial information is distributed across the cortex in a more mixed, sequence-like fashion. It is one of those findings that quietly destabilises the neat picture in the textbooks.
 </p>
 <h2>What I Actually Did</h2>
 <p>
@@ -176,10 +176,10 @@ My job description was much more mundane than the science, but it was indispensa
 </ul>
 <h2>Personal Reflection</h2>
 <p>
-It was the only stretch of my career spent embedded in an academic neuroscience environment, and it shaped me more than the line on my CV suggests. Watching the researchers <strong>frame questions, design experiments, argue at lab meetings, and refuse to overinterpret a clean-looking plot</strong> was a quiet education in scientific taste — the kind of taste that does not transfer to engineering directly but informs it permanently.
+It was the only stretch of my career spent embedded in an academic neuroscience environment, and it shaped me more than the line on my CV suggests. Watching the researchers <strong>frame questions, design experiments, argue at lab meetings, and refuse to overinterpret a clean-looking plot</strong> was a quiet education in scientific taste, the kind of taste that does not transfer to engineering directly but informs it permanently.
 </p>
 <p>
-It also clarified something about my own preferences. I love being close to research. I also love shipping things that other people use. The role of <em>scientific software developer</em> — not a PI, not a postdoc, but the engineer who makes the science move faster — is a genuinely good (and difficult!) role, and one that I think research institutes generally underinvest in.
+It also clarified something about my own preferences. I love being close to research. I also love shipping things that other people use. The role of <em>scientific software developer</em>, not a PI, not a postdoc, but the engineer who makes the science move faster, is a genuinely good (and difficult!) role, and one that I think research institutes generally underinvest in.
 </p>
 
       <div class="project-links">

--- a/projects/rag-document-qa.html
+++ b/projects/rag-document-qa.html
@@ -9,21 +9,21 @@
   <meta name="description" content="A retrieval-augmented generation system built for a large European bank, replacing manual SharePoint search with a conversational assistant that answers questions and cites the exact document and page where each answer was found." />
   <meta name="author" content="Stefano Masneri" />
   <meta name="robots" content="index, follow, noai, noimageai" />
-  <title>RAG Document Assistant for Financial Services — Stefano Masneri</title>
+  <title>RAG Document Assistant for Financial Services | Stefano Masneri</title>
   <link rel="canonical" href="https://stefanomasneri.com/projects/rag-document-qa.html" />
 
   <meta property="og:type"        content="article" />
   <meta property="og:site_name"   content="Stefano Masneri" />
   <meta property="og:locale"      content="en_GB" />
   <meta property="og:url"         content="https://stefanomasneri.com/projects/rag-document-qa.html" />
-  <meta property="og:title"       content="RAG Document Assistant for Financial Services — Stefano Masneri" />
+  <meta property="og:title"       content="RAG Document Assistant for Financial Services | Stefano Masneri" />
   <meta property="og:description" content="A retrieval-augmented generation system built for a large European bank, replacing manual SharePoint search with a conversational assistant that answers questions and cites the exact document and page where each answer was found." />
   <meta property="og:image"       content="https://stefanomasneri.com/img/projects/rag-document-qa-og.png" />
   <meta property="og:image:width"  content="1200" />
   <meta property="og:image:height" content="630" />
   <meta property="og:image:alt"   content="RAG Document Assistant for Financial Services" />
   <meta name="twitter:card"        content="summary_large_image" />
-  <meta name="twitter:title"       content="RAG Document Assistant for Financial Services — Stefano Masneri" />
+  <meta name="twitter:title"       content="RAG Document Assistant for Financial Services | Stefano Masneri" />
   <meta name="twitter:description" content="A retrieval-augmented generation system built for a large European bank, replacing manual SharePoint search with a conversational assistant that answers questions and cites the exact document and page where each answer was found." />
   <meta name="twitter:image"       content="https://stefanomasneri.com/img/projects/rag-document-qa-og.png" />
   <meta name="twitter:image:alt"   content="RAG Document Assistant for Financial Services" />
@@ -140,7 +140,7 @@
     <div class="post-lead">A retrieval-augmented generation system built for a large European bank, replacing manual SharePoint search with a conversational assistant that answers questions and cites the exact document and page where each answer was found.</div>
 
     <p>
-While working at <strong>NTT DATA</strong>, I designed and built a document question-answering system for a large European bank. The client held an extensive knowledge base — internal policies, compliance guidelines, product documentation, procedural manuals — stored as PDFs scattered across their SharePoint environment. Finding relevant information required employees to know which document to look for, navigate the folder structure, open the file, and search within it. The goal was to replace that process with a chatbot that could answer questions directly and, critically, point the user to the exact document and page containing the answer.
+While working at <strong>NTT DATA</strong>, I designed and built a document question-answering system for a large European bank. The client held an extensive knowledge base, internal policies, compliance guidelines, product documentation, procedural manuals, stored as PDFs scattered across their SharePoint environment. Finding relevant information required employees to know which document to look for, navigate the folder structure, open the file, and search within it. The goal was to replace that process with a chatbot that could answer questions directly and, critically, point the user to the exact document and page containing the answer.
 </p>
 <p>
 The solution was a <strong>Retrieval-Augmented Generation (RAG)</strong> pipeline, combining semantic search over a vector database with a large language model for answer synthesis.
@@ -153,10 +153,10 @@ The first stage processes all existing PDF documents and builds a searchable ind
   <img src="../img/projects/rag-ingestion.svg" alt="Document ingestion pipeline" width="800" height="280" loading="lazy" />
 </figure>
 <ol>
-  <li><strong>PDF extraction</strong> — each document is parsed page by page, preserving the mapping between text and page number. This granularity is what makes precise citations possible later.</li>
-  <li><strong>Text chunking</strong> — the extracted text is split into overlapping chunks of fixed token length. Overlap ensures that sentences spanning a chunk boundary are not lost; it also means a retrieved chunk always includes enough surrounding context for the LLM to produce a coherent answer.</li>
-  <li><strong>Embedding</strong> — each chunk is passed through an embedding model, which maps it to a dense vector in a high-dimensional semantic space. Chunks with similar meaning end up close together in this space, regardless of exact wording.</li>
-  <li><strong>Vector database</strong> — the resulting vectors are stored and indexed for fast approximate nearest-neighbour lookup. Crucially, each vector record carries metadata: the source filename, the page number, and the original chunk text. The embedding encodes <em>what</em> the chunk means; the metadata records <em>where</em> it came from.</li>
+  <li><strong>PDF extraction</strong>: each document is parsed page by page, preserving the mapping between text and page number. This granularity is what makes precise citations possible later.</li>
+  <li><strong>Text chunking</strong>: the extracted text is split into overlapping chunks of fixed token length. Overlap ensures that sentences spanning a chunk boundary are not lost; it also means a retrieved chunk always includes enough surrounding context for the LLM to produce a coherent answer.</li>
+  <li><strong>Embedding</strong>: each chunk is passed through an embedding model, which maps it to a dense vector in a high-dimensional semantic space. Chunks with similar meaning end up close together in this space, regardless of exact wording.</li>
+  <li><strong>Vector database</strong>: the resulting vectors are stored and indexed for fast approximate nearest-neighbour lookup. Crucially, each vector record carries metadata: the source filename, the page number, and the original chunk text. The embedding encodes <em>what</em> the chunk means; the metadata records <em>where</em> it came from.</li>
 </ol>
 <h2>Query Pipeline</h2>
 <p>
@@ -166,23 +166,23 @@ When a user submits a question, the system answers in real time through a two-st
   <img src="../img/projects/rag-query.svg" alt="Query and answer pipeline" width="800" height="410" loading="lazy" />
 </figure>
 <ol>
-  <li><strong>Query embedding</strong> — the user's question is passed through the same embedding model used during ingestion, producing a query vector in the same semantic space.</li>
-  <li><strong>Similarity search</strong> — the vector database computes cosine similarity between the query vector and all stored chunk vectors, returning the top-K most semantically relevant chunks along with their metadata.</li>
-  <li><strong>Answer generation</strong> — the original question and the retrieved chunks are assembled into a prompt and sent to an LLM. The model synthesises a grounded answer from the provided context rather than relying on its training knowledge, which is essential in a domain where accuracy and traceability matter.</li>
-  <li><strong>Citations</strong> — because each retrieved chunk carries its source filename and page number in the metadata, the system can append precise references to every answer, letting the user verify the information directly in the original document.</li>
+  <li><strong>Query embedding</strong>: the user's question is passed through the same embedding model used during ingestion, producing a query vector in the same semantic space.</li>
+  <li><strong>Similarity search</strong>: the vector database computes cosine similarity between the query vector and all stored chunk vectors, returning the top-K most semantically relevant chunks along with their metadata.</li>
+  <li><strong>Answer generation</strong>: the original question and the retrieved chunks are assembled into a prompt and sent to an LLM. The model synthesises a grounded answer from the provided context rather than relying on its training knowledge, which is essential in a domain where accuracy and traceability matter.</li>
+  <li><strong>Citations</strong>: because each retrieved chunk carries its source filename and page number in the metadata, the system can append precise references to every answer, letting the user verify the information directly in the original document.</li>
 </ol>
 <h2>What the User Sees</h2>
 <p>
-From the employee's perspective, the interaction is a standard chat interface. They type a question in natural language — &quot;What is the escalation procedure for tier-2 complaints?&quot; or &quot;Which products are covered under the cross-border exemption?&quot; — and receive a direct answer with one or more citations of the form <em>Document name, page N</em>. Clicking a citation opens the relevant page of the source PDF.
+From the employee's perspective, the interaction is a standard chat interface. They type a question in natural language, such as &quot;What is the escalation procedure for tier-2 complaints?&quot; or &quot;Which products are covered under the cross-border exemption?&quot;, and receive a direct answer with one or more citations of the form <em>Document name, page N</em>. Clicking a citation opens the relevant page of the source PDF.
 </p>
 <p>
-No need to know which folder anything lives in — you just ask, and you get an answer with a pointer back to the source so you can verify it yourself.
+No need to know which folder anything lives in; you just ask, and you get an answer with a pointer back to the source so you can verify it yourself.
 </p>
 <h2>Technical Notes</h2>
 <ul>
   <li>The same embedding model must be used for both ingestion and query time; any change to the model requires a full re-embedding of the corpus.</li>
   <li>Chunk size and overlap are the main tuning parameters: too small and individual chunks lack context; too large and the retrieved chunks fill the LLM's context window, leaving little room for the answer.</li>
-  <li>Metadata fidelity during PDF parsing is the key engineering challenge — multi-column layouts, headers, footers, and scanned pages all require careful handling to ensure page numbers remain accurate.</li>
+  <li>Metadata fidelity during PDF parsing is the key engineering challenge: multi-column layouts, headers, footers, and scanned pages all require careful handling to ensure page numbers remain accurate.</li>
 </ul>
 
 

--- a/projects/traction.html
+++ b/projects/traction.html
@@ -6,25 +6,25 @@
   <!-- generated:csp-meta -->
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://nominatim.openstreetmap.org; media-src 'self'; worker-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; manifest-src 'self'; upgrade-insecure-requests" />
   <!-- /generated:csp-meta -->
-  <meta name="description" content="TRACTION was a Horizon 2020 project, coordinated by Vicomtech, that used opera as a vehicle for social inclusion. My work centred on the Co-creation Stage — the real-time distributed performance tool — spanning development, user-requirements gathering, evaluation, and direct engagement with artistic and community partners across Barcelona, Leiria and Ireland." />
+  <meta name="description" content="TRACTION was a Horizon 2020 project, coordinated by Vicomtech, that used opera as a vehicle for social inclusion. My work centred on the Co-creation Stage, the real-time distributed performance tool, spanning development, user-requirements gathering, evaluation, and direct engagement with artistic and community partners across Barcelona, Leiria and Ireland." />
   <meta name="author" content="Stefano Masneri" />
   <meta name="robots" content="index, follow, noai, noimageai" />
-  <title>TRACTION: Opera Co-creation for Inclusion — Stefano Masneri</title>
+  <title>TRACTION: Opera Co-creation for Inclusion | Stefano Masneri</title>
   <link rel="canonical" href="https://stefanomasneri.com/projects/traction.html" />
 
   <meta property="og:type"        content="article" />
   <meta property="og:site_name"   content="Stefano Masneri" />
   <meta property="og:locale"      content="en_GB" />
   <meta property="og:url"         content="https://stefanomasneri.com/projects/traction.html" />
-  <meta property="og:title"       content="TRACTION: Opera Co-creation for Inclusion — Stefano Masneri" />
-  <meta property="og:description" content="TRACTION was a Horizon 2020 project, coordinated by Vicomtech, that used opera as a vehicle for social inclusion. My work centred on the Co-creation Stage — the real-time distributed performance tool — spanning development, user-requirements gathering, evaluation, and direct engagement with artistic and community partners across Barcelona, Leiria and Ireland." />
+  <meta property="og:title"       content="TRACTION: Opera Co-creation for Inclusion | Stefano Masneri" />
+  <meta property="og:description" content="TRACTION was a Horizon 2020 project, coordinated by Vicomtech, that used opera as a vehicle for social inclusion. My work centred on the Co-creation Stage, the real-time distributed performance tool, spanning development, user-requirements gathering, evaluation, and direct engagement with artistic and community partners across Barcelona, Leiria and Ireland." />
   <meta property="og:image"       content="https://stefanomasneri.com/img/projects/traction-bg.webp" />
   <meta property="og:image:width"  content="800" />
   <meta property="og:image:height" content="533" />
   <meta property="og:image:alt"   content="TRACTION: Opera Co-creation for Social Transformation" />
   <meta name="twitter:card"        content="summary_large_image" />
-  <meta name="twitter:title"       content="TRACTION: Opera Co-creation for Inclusion — Stefano Masneri" />
-  <meta name="twitter:description" content="TRACTION was a Horizon 2020 project, coordinated by Vicomtech, that used opera as a vehicle for social inclusion. My work centred on the Co-creation Stage — the real-time distributed performance tool — spanning development, user-requirements gathering, evaluation, and direct engagement with artistic and community partners across Barcelona, Leiria and Ireland." />
+  <meta name="twitter:title"       content="TRACTION: Opera Co-creation for Inclusion | Stefano Masneri" />
+  <meta name="twitter:description" content="TRACTION was a Horizon 2020 project, coordinated by Vicomtech, that used opera as a vehicle for social inclusion. My work centred on the Co-creation Stage, the real-time distributed performance tool, spanning development, user-requirements gathering, evaluation, and direct engagement with artistic and community partners across Barcelona, Leiria and Ireland." />
   <meta name="twitter:image"       content="https://stefanomasneri.com/img/projects/traction-bg.webp" />
   <meta name="twitter:image:alt"   content="TRACTION: Opera Co-creation for Social Transformation" />
 
@@ -71,7 +71,7 @@
     "@context": "https://schema.org",
     "@type": "Article",
     "headline": "TRACTION: Opera Co-creation for Inclusion",
-    "description": "TRACTION was a Horizon 2020 project, coordinated by Vicomtech, that used opera as a vehicle for social inclusion. My work centred on the Co-creation Stage — the real-time distributed performance tool — spanning development, user-requirements gathering, evaluation, and direct engagement with artistic and community partners across Barcelona, Leiria and Ireland.",
+    "description": "TRACTION was a Horizon 2020 project, coordinated by Vicomtech, that used opera as a vehicle for social inclusion. My work centred on the Co-creation Stage, the real-time distributed performance tool, spanning development, user-requirements gathering, evaluation, and direct engagement with artistic and community partners across Barcelona, Leiria and Ireland.",
     "image": "https://stefanomasneri.com/img/projects/traction-bg.webp",
     "author": {
       "@type": "Person",
@@ -137,21 +137,21 @@
   </header>
 
   <main id="project-content" class="post">
-    <div class="post-lead">TRACTION was a Horizon 2020 project, coordinated by Vicomtech, that used opera as a vehicle for social inclusion. My work centred on the Co-creation Stage — the real-time distributed performance tool — spanning development, user-requirements gathering, evaluation, and direct engagement with artistic and community partners across Barcelona, Leiria and Ireland.</div>
+    <div class="post-lead">TRACTION was a Horizon 2020 project, coordinated by Vicomtech, that used opera as a vehicle for social inclusion. My work centred on the Co-creation Stage, the real-time distributed performance tool, spanning development, user-requirements gathering, evaluation, and direct engagement with artistic and community partners across Barcelona, Leiria and Ireland.</div>
 
     <p>
-TRACTION (<em>Opera co-creation for a social transformation</em>) was a three-year EU Horizon 2020 research and innovation action that ran from <strong>January 2020 to December 2022</strong>, coordinated by <strong>Vicomtech</strong> and with a total budget of roughly <strong>€3.75M</strong>. The project set out to do something deceptively simple: take opera — an art form often perceived as elitist and inaccessible — and turn it back into a vehicle for social and cultural inclusion, by giving marginalised communities the tools to <strong>co-create</strong> opera performances alongside professional artists.
+TRACTION (<em>Opera co-creation for a social transformation</em>) was a three-year EU Horizon 2020 research and innovation action that ran from <strong>January 2020 to December 2022</strong>, coordinated by <strong>Vicomtech</strong> and with a total budget of roughly <strong>€3.75M</strong>. The project set out to do something deceptively simple: take opera, an art form often perceived as elitist and inaccessible, and turn it back into a vehicle for social and cultural inclusion, by giving marginalised communities the tools to <strong>co-create</strong> opera performances alongside professional artists.
 </p>
 <p>
 That ambition was tested in three very different places: the inner-city neighbourhoods of <strong>Barcelona</strong> (Raval), a youth prison in <strong>Leiria, Portugal</strong>, and the rural communities of <strong>Ireland</strong>. The technological backbone of the project was a pair of digital platforms developed at Vicomtech and CWI: the <strong>Co-creation Space</strong> and the <strong>Co-creation Stage</strong>.
 </p>
 <h2>My Role</h2>
 <p>
-My main contribution was to the <strong>Co-creation Stage</strong> — the real-time distributed performance tool that allowed a single opera to be staged simultaneously across multiple co-located venues, synchronising live video, audio and interaction between stages. I was involved across the full lifecycle, in a role that combined technical development with research and partnership activities:
+My main contribution was to the <strong>Co-creation Stage</strong>, the real-time distributed performance tool that allowed a single opera to be staged simultaneously across multiple co-located venues, synchronising live video, audio and interaction between stages. I was involved across the full lifecycle, in a role that combined technical development with research and partnership activities:
 </p>
 <ul>
   <li><strong>Development</strong>: working on both the frontend and the backend of the Stage, contributing to the low-latency adaptive media transmission layer that made synchronised live performance across venues possible.</li>
-  <li><strong>User-requirements gathering</strong>: working closely with the artistic partners — Liceu in Barcelona, SAMP in Leiria, Irish National Opera in Ireland — and with sociologists and community educators to translate what professional artists and community participants actually needed into concrete software features.</li>
+  <li><strong>User-requirements gathering</strong>: working closely with the artistic partners, Liceu in Barcelona, SAMP in Leiria, Irish National Opera in Ireland, and with sociologists and community educators to translate what professional artists and community participants actually needed into concrete software features.</li>
   <li><strong>Evaluation</strong>: designing and running usability studies and field trials, collecting and analysing feedback, and feeding findings back into the design and development loop.</li>
   <li><strong>Partner engagement</strong>: maintaining ongoing dialogue with consortium partners across research, opera, education and prison-work organisations in five countries, bridging the gap between technical decisions and the realities of the artistic and community use cases.</li>
 </ul>
@@ -163,12 +163,12 @@ The Co-creation Stage was the centrepiece of the live-performance moments: a pro
 The Co-creation Stage is a real-time distributed performance application:
 </p>
 <ul>
-  <li><strong>Frontend</strong> — Angular with TypeScript, designed for multi-venue operator interfaces and audience-facing views.</li>
-  <li><strong>Backend</strong> — low-latency adaptive media transmission to synchronise live video and audio across geographically separated stages in real time.</li>
-  <li><strong>Deployment</strong> — containerised services orchestrated to support live events with strict latency requirements.</li>
+  <li><strong>Frontend</strong>: Angular with TypeScript, designed for multi-venue operator interfaces and audience-facing views.</li>
+  <li><strong>Backend</strong>: low-latency adaptive media transmission to synchronise live video and audio across geographically separated stages in real time.</li>
+  <li><strong>Deployment</strong>: containerised services orchestrated to support live events with strict latency requirements.</li>
 </ul>
 <p>
-The companion <strong>Co-creation Space</strong> — the asynchronous collaboration platform built mainly by colleagues — used a different stack (Node.js / TypeScript / Express backend; React / Redux frontend; PostgreSQL + MongoDB for storage; AWS S3 + Elastic Transcoder for media; WebSockets for real-time notifications) and was designed for the ongoing creative process between live events.
+The companion <strong>Co-creation Space</strong>, the asynchronous collaboration platform built mainly by colleagues, used a different stack (Node.js / TypeScript / Express backend; React / Redux frontend; PostgreSQL + MongoDB for storage; AWS S3 + Elastic Transcoder for media; WebSockets for real-time notifications) and was designed for the ongoing creative process between live events.
 </p>
 <h2>Outcomes</h2>
 <p>
@@ -176,7 +176,7 @@ By the end of the project, the two tools had supported three full community oper
 </p>
 <ul>
   <li>In <strong>Barcelona</strong>, <a href="https://www.liceubarcelona.cat/en/liceu-apropa/la-gata-perduda" target="_blank" rel="noopener"><em>La Gata Perduda</em></a> was performed twice at the Liceu Opera House to sold-out audiences in October 2022, with a choir formed from twelve amateur choirs from the Raval. The Catalan public broadcast reached around 766,000 viewers. The <a href="https://www.traction-project.eu/trials/liceu/" target="_blank" rel="noopener">TRACTION project page for the Liceu trial</a> documents the full co-creation process behind the production.</li>
-  <li>In <strong>Leiria</strong>, <em>O Tempo (Somos Nós)</em> — produced with SAMP and the young inmates, their relatives and prison workers — was performed four times in June 2022: twice inside the prison and twice at the Gulbenkian's main concert hall in Lisbon.</li>
+  <li>In <strong>Leiria</strong>, <em>O Tempo (Somos Nós)</em>, produced with SAMP and the young inmates, their relatives and prison workers, was performed four times in June 2022: twice inside the prison and twice at the Gulbenkian's main concert hall in Lisbon.</li>
   <li>In <strong>Ireland</strong>, <em>Out of the Ordinary / As an nGnách</em> became the world's first virtual reality community opera, co-created with rural teenagers and toured around the country.</li>
 </ul>
 <p>
@@ -187,7 +187,7 @@ Survey data from participants reported that 94% felt actively involved, 89% lear
 What stayed with me long after the project finished is what the technology <em>enabled</em> rather than what the technology <em>was</em>. A platform for sharing videos, comments and audio clips is, in pure software terms, not a remarkable thing. But put it in the hands of a teenager in a juvenile detention centre who has spent years being told their voice does not matter, and the same software becomes a way to record a song that ends up performed at the Gulbenkian concert hall in front of their family. Put it in the hands of a migrant choir in Raval, and it becomes the connective tissue of an opera that fills the Liceu.
 </p>
 <p>
-That is also where the responsibility of the technical role becomes very tangible: every design choice — what is private and what is shared, who can comment on what, how reliable the upload is on a tablet on a slow connection inside a prison — has consequences that go far beyond a usability metric. Building software that is going to be used in those settings requires a different kind of attention than building software for a generic &quot;user&quot;.
+That is also where the responsibility of the technical role becomes very tangible: every design choice, what is private and what is shared, who can comment on what, how reliable the upload is on a tablet on a slow connection inside a prison, has consequences that go far beyond a usability metric. Building software that is going to be used in those settings requires a different kind of attention than building software for a generic &quot;user&quot;.
 </p>
 
       <div class="project-links">

--- a/projects/ufc-fighter-tracking.html
+++ b/projects/ufc-fighter-tracking.html
@@ -9,21 +9,21 @@
   <meta name="description" content="End-to-end real-time analytics for live UFC events: stereo computer vision in the truss above the octagon, accelerometers in the gloves, GPU inference at the venue, and statistics streamed to fans worldwide. Built at AGT International in 2017 and demoed live by our CEO during Werner Vogels' keynote at AWS re:Invent 2017." />
   <meta name="author" content="Stefano Masneri" />
   <meta name="robots" content="index, follow, noai, noimageai" />
-  <title>UFC Fighter Tracking: Multi-Modal Sensing — Stefano Masneri</title>
+  <title>UFC Fighter Tracking: Multi-Modal Sensing | Stefano Masneri</title>
   <link rel="canonical" href="https://stefanomasneri.com/projects/ufc-fighter-tracking.html" />
 
   <meta property="og:type"        content="article" />
   <meta property="og:site_name"   content="Stefano Masneri" />
   <meta property="og:locale"      content="en_GB" />
   <meta property="og:url"         content="https://stefanomasneri.com/projects/ufc-fighter-tracking.html" />
-  <meta property="og:title"       content="UFC Fighter Tracking: Multi-Modal Sensing — Stefano Masneri" />
+  <meta property="og:title"       content="UFC Fighter Tracking: Multi-Modal Sensing | Stefano Masneri" />
   <meta property="og:description" content="End-to-end real-time analytics for live UFC events: stereo computer vision in the truss above the octagon, accelerometers in the gloves, GPU inference at the venue, and statistics streamed to fans worldwide. Built at AGT International in 2017 and demoed live by our CEO during Werner Vogels' keynote at AWS re:Invent 2017." />
   <meta property="og:image"       content="https://stefanomasneri.com/img/projects/ufc-octagon-bg.webp" />
   <meta property="og:image:width"  content="1536" />
   <meta property="og:image:height" content="1024" />
   <meta property="og:image:alt"   content="UFC Fighter Tracking: Multi-Modal Sensing in the Octagon" />
   <meta name="twitter:card"        content="summary_large_image" />
-  <meta name="twitter:title"       content="UFC Fighter Tracking: Multi-Modal Sensing — Stefano Masneri" />
+  <meta name="twitter:title"       content="UFC Fighter Tracking: Multi-Modal Sensing | Stefano Masneri" />
   <meta name="twitter:description" content="End-to-end real-time analytics for live UFC events: stereo computer vision in the truss above the octagon, accelerometers in the gloves, GPU inference at the venue, and statistics streamed to fans worldwide. Built at AGT International in 2017 and demoed live by our CEO during Werner Vogels' keynote at AWS re:Invent 2017." />
   <meta name="twitter:image"       content="https://stefanomasneri.com/img/projects/ufc-octagon-bg.webp" />
   <meta name="twitter:image:alt"   content="UFC Fighter Tracking: Multi-Modal Sensing in the Octagon" />
@@ -140,38 +140,38 @@
     <div class="post-lead">End-to-end real-time analytics for live UFC events: stereo computer vision in the truss above the octagon, accelerometers in the gloves, GPU inference at the venue, and statistics streamed to fans worldwide. Built at AGT International in 2017 and demoed live by our CEO during Werner Vogels' keynote at AWS re:Invent 2017.</div>
 
     <p>
-This is one of the projects I tell people about when they ask what the most fun thing I have ever worked on was. In <strong>2017</strong>, while I was a Senior Data Scientist at <strong>AGT International</strong> in Darmstadt, our team built a real-time fighter-tracking and analytics system for the <strong>UFC</strong>. The product was launched as part of <strong>HEED</strong>, AGT's IoT-driven sports platform, and was presented in a live demonstration by our CEO <strong>Mati Kochavi</strong> during AWS CTO Werner Vogels' keynote at <strong>AWS re:Invent 2017</strong> in Las Vegas — see the <a href="https://www.youtube.com/watch?v=vataVq9gY_o" target="_blank" rel="noopener">recording on YouTube</a>.
+This is one of the projects I tell people about when they ask what the most fun thing I have ever worked on was. In <strong>2017</strong>, while I was a Senior Data Scientist at <strong>AGT International</strong> in Darmstadt, our team built a real-time fighter-tracking and analytics system for the <strong>UFC</strong>. The product was launched as part of <strong>HEED</strong>, AGT's IoT-driven sports platform, and was presented in a live demonstration by our CEO <strong>Mati Kochavi</strong> during AWS CTO Werner Vogels' keynote at <strong>AWS re:Invent 2017</strong> in Las Vegas (see the <a href="https://www.youtube.com/watch?v=vataVq9gY_o" target="_blank" rel="noopener">recording on YouTube</a>).
 </p>
 <p>
 The brief was easy to state, but the implementation was very complex: produce real-time, broadcast-quality statistics for an MMA fight, generated from the cage itself, with no human operator pressing buttons. The system had to work everywhere the UFC went, install in hours (usually the day before the event), survive the production environment of a live televised event, and feed numbers into the official mobile app while the fight was still happening.
 </p>
 <figure>
-  <img src="../img/projects/ufc-octagon-overhead.webp" alt="UFC octagon from above — camera coverage" width="1600" height="900" loading="lazy" />
+  <img src="../img/projects/ufc-octagon-overhead.webp" alt="UFC octagon from above, camera coverage" width="1600" height="900" loading="lazy" />
 </figure>
 <h2>What We Measured</h2>
 <p>
 The output of the system was a continuous stream of statistics for each of the two fighters:
 </p>
 <ul>
-  <li><strong>Position and speed</strong> — every fighter's location inside the octagon, sampled many times per second.</li>
-  <li><strong>Octagon control</strong> — which fighter was occupying the centre vs. being pushed against the cage, computed from the relative positions over time.</li>
-  <li><strong>Total movement</strong> — distance covered by each fighter through a round and across the fight.</li>
-  <li><strong>Posture state</strong> — <em>standing</em> vs. <em>on the ground</em>, with transitions timestamped so the broadcast could show &quot;X seconds of ground game&quot;.</li>
-  <li><strong>Strike counts</strong> — kicks and punches, separated by type (jab, hook, uppercut, …) and by <em>attempted</em> vs. <em>landed</em>.</li>
+  <li><strong>Position and speed</strong>: every fighter's location inside the octagon, sampled many times per second.</li>
+  <li><strong>Octagon control</strong>: which fighter was occupying the centre vs. being pushed against the cage, computed from the relative positions over time.</li>
+  <li><strong>Total movement</strong>: distance covered by each fighter through a round and across the fight.</li>
+  <li><strong>Posture state</strong>: <em>standing</em> vs. <em>on the ground</em>, with transitions timestamped so the broadcast could show &quot;X seconds of ground game&quot;.</li>
+  <li><strong>Strike counts</strong>: kicks and punches, separated by type (jab, hook, uppercut, …) and by <em>attempted</em> vs. <em>landed</em>.</li>
 </ul>
 <p>
 All of this was published to the cloud, aggregated, and pushed to the consumer-facing UFC app and to broadcast graphics in near real time.
 </p>
 <h2>Hardware in the Truss</h2>
 <p>
-Coverage of a UFC octagon — eight sides, fast lateral motion, frequent occlusions when fighters clinched — was the first hard problem. We solved it with <strong>two <a href="https://www.stereolabs.com/" target="_blank" rel="noopener">Stereolabs ZED</a> RGB-D cameras</strong> mounted on the <strong>truss above the cage</strong>, angled to give overlapping fields of view that covered the entire fighting surface. The depth channel was crucial: knowing the distance of each fighter from the camera let us resolve the ambiguities that single RGB streams suffered from, especially during ground exchanges.
+Coverage of a UFC octagon, with eight sides, fast lateral motion, and frequent occlusions when fighters clinched, was the first hard problem. We solved it with <strong>two <a href="https://www.stereolabs.com/" target="_blank" rel="noopener">Stereolabs ZED</a> RGB-D cameras</strong> mounted on the <strong>truss above the cage</strong>, angled to give overlapping fields of view that covered the entire fighting surface. The depth channel was crucial: knowing the distance of each fighter from the camera let us resolve the ambiguities that single RGB streams suffered from, especially during ground exchanges.
 </p>
 <p>
-Both cameras were cabled to a <strong>GPU-equipped PC, also mounted on the truss</strong>, which performed all the perception work locally. Doing inference at the venue (rather than streaming raw footage to a remote machine) was a deliberate choice — it eliminated the network as a bottleneck, kept latency in the sub-second range, and meant the system kept working even when venue connectivity wobbled. The PC then streamed only the resulting statistics down to the cloud over a much narrower data path.
+Both cameras were cabled to a <strong>GPU-equipped PC, also mounted on the truss</strong>, which performed all the perception work locally. Doing inference at the venue (rather than streaming raw footage to a remote machine) was a deliberate choice; it eliminated the network as a bottleneck, kept latency in the sub-second range, and meant the system kept working even when venue connectivity wobbled. The PC then streamed only the resulting statistics down to the cloud over a much narrower data path.
 </p>
 <h2>Sensor Fusion: Vision + Accelerometers</h2>
 <p>
-Pure vision could detect that a punch had been <em>thrown</em>, but not whether it had <em>connected</em> — and certainly not the punch <em>type</em> with the precision the UFC wanted. The fix was multi-modal: a parallel sensor team had instrumented the fighters' <strong>gloves with accelerometers</strong>, providing a second, completely independent signal for every strike.
+Pure vision could detect that a punch had been <em>thrown</em>, but not whether it had <em>connected</em>, and certainly not the punch <em>type</em> with the precision the UFC wanted. The fix was multi-modal: a parallel sensor team had instrumented the fighters' <strong>gloves with accelerometers</strong>, providing a second, completely independent signal for every strike.
 </p>
 <p>
 We fused the two streams in real time:
@@ -186,17 +186,17 @@ We fused the two streams in real time:
 </figure>
 <h2>Cloud and Delivery</h2>
 <p>
-Once produced at the edge, the statistics were ingested through <strong>AWS</strong> services (Kinesis for ingestion, downstream services for processing, persistence, and fan-out — see <a href="https://www.youtube.com/watch?v=zHSEnKb69go" target="_blank" rel="noopener">AGT's separate AWS re:Invent 2017 talk on the Kinesis side of the architecture</a>). From there they were relayed to the UFC app and to broadcast partners.
+Once produced at the edge, the statistics were ingested through <strong>AWS</strong> services (Kinesis for ingestion, downstream services for processing, persistence, and fan-out; see <a href="https://www.youtube.com/watch?v=zHSEnKb69go" target="_blank" rel="noopener">AGT's separate AWS re:Invent 2017 talk on the Kinesis side of the architecture</a>). From there they were relayed to the UFC app and to broadcast partners.
 </p>
 <p>
 This was a project where I was involved <strong>end to end</strong>:
 </p>
 <ul>
-  <li><strong>Algorithm design</strong> — I worked on the perception side: detection, tracking, posture classification, and the matching logic that fused vision with the accelerometer stream.</li>
-  <li><strong>Network and edge architecture</strong> — choices about where computation happened (truss vs. cloud), how data moved between components, and how the system behaved under network degradation.</li>
-  <li><strong>Product ownership</strong> — translating between what the UFC wanted as a product (clean, interpretable, defensible numbers) and what we could measure as engineers.</li>
-  <li><strong>Customer-facing point of contact</strong> — direct contact with the UFC and with the sensor team that built the glove instrumentation, coordinating their hardware and our software so the two halves of the system actually shipped as one product.</li>
-  <li><strong>Live deployment</strong> — I travelled to multiple live events around the world to install, calibrate, and operate the system on fight nights.</li>
+  <li><strong>Algorithm design</strong>: I worked on the perception side: detection, tracking, posture classification, and the matching logic that fused vision with the accelerometer stream.</li>
+  <li><strong>Network and edge architecture</strong>: choices about where computation happened (truss vs. cloud), how data moved between components, and how the system behaved under network degradation.</li>
+  <li><strong>Product ownership</strong>: translating between what the UFC wanted as a product (clean, interpretable, defensible numbers) and what we could measure as engineers.</li>
+  <li><strong>Customer-facing point of contact</strong>: direct contact with the UFC and with the sensor team that built the glove instrumentation, coordinating their hardware and our software so the two halves of the system actually shipped as one product.</li>
+  <li><strong>Live deployment</strong>: I travelled to multiple live events around the world to install, calibrate, and operate the system on fight nights.</li>
 </ul>
 
       <div class="project-links">


### PR DESCRIPTION
Replace all em dashes in visible text across every HTML page and data
file with contextually appropriate punctuation:
- Page title separators use | (index, cv, projects, 404, all project pages)
- Labeled list items (e.g. Term — desc) use :
- Parenthetical asides use commas; independent clauses use semicolons
- CV degree names updated (PhD — CS → PhD in CS)
- Language proficiency levels updated (C2 — Proficient → C2: Proficient)
- data/cv.yaml updated and cv.js regenerated; data/projects.js updated

Change "Research" section tag to "Focus" in index.html, reflecting that
the What I Work On section describes applied engineering domains rather
than academic research.

https://claude.ai/code/session_019AqvBPkagdktgMBSjrw8PM