### PR TITLE
Fix duplicate count in links filter label; simplify intro text

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -688,7 +688,7 @@ function wireLinksFilter(container) {
   toolbar.addEventListener('click', (e) => {
     const chip = e.target.closest && e.target.closest('.link-chip');
     if (!chip || !toolbar.contains(chip)) return;
-    apply(chip.getAttribute('data-filter'), chip.textContent.trim());
+    apply(chip.getAttribute('data-filter'), chip.getAttribute('data-label') || chip.textContent.trim());
   });
 }
 
@@ -718,10 +718,10 @@ export function renderLinks(container, data) {
   }
 
   const chips = [
-    `<button class="link-chip is-active" type="button" data-filter="all" aria-pressed="true">` +
+    `<button class="link-chip is-active" type="button" data-filter="all" data-label="All" aria-pressed="true">` +
     `All <span class="link-chip-count">${links.length}</span></button>`,
   ].concat(categories.map((cat) => (
-    `<button class="link-chip" type="button" data-filter="${escapeHtml(cat.slug)}" aria-pressed="false">` +
+    `<button class="link-chip" type="button" data-filter="${escapeHtml(cat.slug)}" data-label="${escapeHtml(cat.label)}" aria-pressed="false">` +
     `${escapeHtml(cat.label)} <span class="link-chip-count">${countOf.get(cat.slug) || 0}</span></button>`
   ))).join('');
 

--- a/links.html
+++ b/links.html
@@ -106,11 +106,8 @@
         <span class="section-tag">Blogroll</span>
         <h1 class="section-title">Links</h1>
         <p class="links-intro">
-          A small, hand-picked list of websites and technical blogs I keep
-          coming back to. Less a directory than a snapshot of my taste &mdash;
-          the people whose writing has taught me the most. Use the filters to
-          narrow by category; pruned whenever I stop reading, so everything
-          here still earns its place.
+          A short list of websites and blogs I like and keep coming back to &mdash;
+          mostly places where I go to learn something new. Use the filters to browse by topic.
         </p>
       </header>
 

--- a/links.html
+++ b/links.html
@@ -106,7 +106,7 @@
         <span class="section-tag">Blogroll</span>
         <h1 class="section-title">Links</h1>
         <p class="links-intro">
-          A short list of websites and blogs I like and keep coming back to &mdash;
+          A short list of websites and blogs I like and keep coming back to,
           mostly places where I go to learn something new. Use the filters to browse by topic.
         </p>
       </header>


### PR DESCRIPTION
The chip textContent included the embedded count span, so clicking a
category chip passed e.g. "AI 5" as the label to linksCountLabel, which
then rendered "Showing 5 sites in AI 5". Fixed by adding a data-label
attribute to each chip and reading that instead of textContent.

Also simplified the links page intro to be shorter and more natural.

https://claude.ai/code/session_017yutyuafnwiGurzhLCVJc5