### PR TITLE
Fix mobile menu overlay collapsing when opened after scrolling

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -13,4 +13,19 @@ if ! command -v node &>/dev/null; then
 fi
 
 echo "Node.js $(node --version) available"
+
+# Install dependencies so the test suite can run. The Three.js-dependent
+# tests import the `three` package via js/three-context.js; without an
+# install they silently fail to load. Fresh web containers start with no
+# node_modules, so install on first session start.
+if [ ! -d node_modules ]; then
+  echo "Installing dependencies (npm ci)..."
+  if [ -f package-lock.json ]; then
+    npm ci
+  else
+    npm install
+  fi
+  echo "Dependencies installed."
+fi
+
 echo "Session start hook complete."

--- a/css/styles.css
+++ b/css/styles.css
@@ -305,17 +305,31 @@ h3 {
   align-items: center;
   padding-inline: clamp(1.25rem, 5vw, 3rem);
 
-  /* Starts transparent, gains blur on scroll via JS */
+  /* Transparent bar; the blurred background fades in on scroll via the
+     ::before pseudo-element (see #navbar.scrolled::before below). */
   background: transparent;
-  transition: background var(--t-med) var(--ease),
-    backdrop-filter var(--t-med) var(--ease),
-    box-shadow var(--t-med) var(--ease);
 }
 
-#navbar.scrolled {
+/* Render the scrolled bar's background + blur on a pseudo-element instead of
+   #navbar itself. A non-none backdrop-filter on #navbar would make it the
+   containing block for its fixed-position descendants, which would break the
+   mobile menu overlay (.nav-links) — it'd be sized against the 68px navbar
+   instead of the viewport. Keeping the filter on ::before avoids that trap.
+   It's always present (opacity 0) so the scroll-in still fades smoothly. */
+#navbar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
   background: rgb(var(--bg-rgb) / 0.85);
   backdrop-filter: blur(18px) saturate(1.4);
   box-shadow: 0 1px 0 var(--border);
+  opacity: 0;
+  transition: opacity var(--t-med) var(--ease);
+}
+
+#navbar.scrolled::before {
+  opacity: 1;
 }
 
 .nav-inner {


### PR DESCRIPTION
The scrolled navbar applied backdrop-filter directly to #navbar, which
makes it the containing block for its fixed-position descendants. The
mobile menu (.nav-links, position:fixed inset:nav-h 0 0 0) was then sized
against the 68px navbar instead of the viewport, so the overlay collapsed
and page content showed through once the page was scrolled.

Move the blurred bar background onto a #navbar::before pseudo-element
(opacity fades in on .scrolled) so #navbar no longer establishes a fixed
containing block. The menu now fills the screen at any scroll position.