### PR TITLE
Fix WebGL resource leak in NeuralNetwork.destroy + sanitize markdown link hrefs

### DIFF
--- a/js/neural-net.js
+++ b/js/neural-net.js
@@ -317,6 +317,43 @@ export class NeuralNetwork {
       try { target.removeEventListener(type, fn, opts); } catch (_) { /* ignore */ }
     }
     this._listeners = [];
+
+    /* Walk the scene tree and free GPU resources (geometries, materials and
+       their textures — e.g. the additive glow map on the points material).
+       Mirrors Globe3D.destroy(); guarded so test mocks without dispose() are
+       safe. Without this the renderer, geometries and glow texture leak on
+       every pagehide / bfcache eviction. */
+    if (this.scene && Array.isArray(this.scene.children)) {
+      const visit = (obj) => {
+        if (!obj) return;
+        if (obj.geometry && typeof obj.geometry.dispose === 'function') obj.geometry.dispose();
+        const mat = obj.material;
+        if (mat) {
+          const mats = Array.isArray(mat) ? mat : [mat];
+          for (const m of mats) {
+            if (m && typeof m.dispose === 'function') m.dispose();
+            for (const key of ['map', 'alphaMap']) {
+              if (m && m[key] && typeof m[key].dispose === 'function') m[key].dispose();
+            }
+          }
+        }
+        if (Array.isArray(obj.children)) obj.children.forEach(visit);
+      };
+      this.scene.children.forEach(visit);
+    }
+
+    if (this.renderer) {
+      try {
+        if (typeof this.renderer.dispose === 'function') this.renderer.dispose();
+        if (typeof this.renderer.forceContextLoss === 'function') this.renderer.forceContextLoss();
+      } catch (_) { /* ignore */ }
+    }
+
+    this.scene = null;
+    this.renderer = null;
+    this.points = null;
+    this.lines = null;
+    this.lineGeo = null;
   }
 }
 

--- a/scripts/new-project.js
+++ b/scripts/new-project.js
@@ -147,7 +147,17 @@ function applyInline(text) {
   text = text.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
   text = text.replace(/\*(.+?)\*/g, '<em>$1</em>');
   text = text.replace(/(?<!\w)_(.+?)_(?!\w)/g, '<em>$1</em>');
-  text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+  text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, label, url) => {
+    /* The text is already HTML-escaped, so quotes can't break out of the
+       attribute — but the protocol still has to be vetted to keep
+       javascript:/data: links out of the generated href. Allow http(s),
+       mailto, fragments and site-relative paths; anything else is left as
+       inert text. */
+    const raw = url.trim();
+    if (!/^(https?:\/\/|mailto:|[/#])/i.test(raw)) return `[${label}](${url})`;
+    const rel = /^https?:\/\//i.test(raw) ? ' target="_blank" rel="noopener noreferrer"' : '';
+    return `<a href="${raw}"${rel}>${label}</a>`;
+  });
   return text;
 }
 

--- a/test/main.node.test.mjs
+++ b/test/main.node.test.mjs
@@ -600,6 +600,7 @@ test('NeuralNetwork constructs and updates with mocked THREE', () => {
   global.IntersectionObserver = class {
     constructor(cb) { this.cb = cb; }
     observe() {}
+    disconnect() {}
   };
   global.requestAnimationFrame = () => 1;
   global.cancelAnimationFrame = () => {};
@@ -609,6 +610,29 @@ test('NeuralNetwork constructs and updates with mocked THREE', () => {
     assert.ok(nn.points);
     assert.ok(nn.lines);
     assert.ok(nn.lineGeo);
+
+    /* destroy() must free GPU resources (geometries, materials and the glow
+       texture) and drop the renderer/scene refs — otherwise they leak on every
+       pagehide / bfcache eviction. The mock objects have no dispose() of their
+       own, so we attach spies and assert destroy() walks the scene. */
+    const disposed = [];
+    const spy = (obj, tag) => { if (obj) obj.dispose = () => disposed.push(tag); };
+    spy(nn.points.geometry, 'points.geo');
+    spy(nn.points.material, 'points.mat');
+    spy(nn.points.material && nn.points.material.map, 'points.map');
+    spy(nn.lines.geometry, 'lines.geo');
+    spy(nn.lines.material, 'lines.mat');
+    nn.renderer.dispose = () => disposed.push('renderer');
+
+    nn.destroy();
+
+    assert.ok(disposed.includes('points.geo'), 'destroy must dispose the points geometry');
+    assert.ok(disposed.includes('points.mat'), 'destroy must dispose the points material');
+    assert.ok(disposed.includes('points.map'), 'destroy must dispose the glow texture');
+    assert.ok(disposed.includes('lines.geo'), 'destroy must dispose the lines geometry');
+    assert.ok(disposed.includes('renderer'), 'destroy must dispose the renderer');
+    assert.equal(nn.scene, null, 'destroy must drop the scene ref');
+    assert.equal(nn.renderer, null, 'destroy must drop the renderer ref');
   } finally {
     global.window = prevWindow;
     global.document = prevDocument;

--- a/test/new-project.test.js
+++ b/test/new-project.test.js
@@ -127,6 +127,13 @@ test('project: markdownToHtml converts bold text', () => {
 test('project: markdownToHtml converts links', () => {
   const html = markdownToHtml('[click](https://example.com)');
   assert.match(html, /href="https:\/\/example\.com"/);
+  assert.match(html, /rel="noopener noreferrer"/);
+});
+
+test('project: markdownToHtml refuses javascript: links', () => {
+  const html = markdownToHtml('[click](javascript:alert(1))');
+  assert.doesNotMatch(html, /href="javascript:/i);
+  assert.doesNotMatch(html, /<a /);
 });
 
 test('project: markdownToHtml converts unordered lists', () => {


### PR DESCRIPTION
- NeuralNetwork.destroy() now walks the scene tree to dispose geometries,
  materials and the additive glow texture, and disposes the renderer
  (mirrors Globe3D.destroy()). Previously only RAF + listeners were torn
  down, leaking GPU resources on every pagehide / bfcache eviction.
- new-project.js markdown links now vet the URL protocol (http(s), mailto,
  fragment, site-relative only) so javascript:/data: links can't end up in a
  generated href; external links get rel="noopener noreferrer".
- Add regression tests for both.