### PR TITLE
Comprehensive site review: CSS modernization, aesthetic refresh, a11y & perf

### DIFF
--- a/data/palettes.yaml
+++ b/data/palettes.yaml
@@ -28,7 +28,7 @@ palettes:
     # ── Text tiers ──
     text: '#e8eee5'
     textMuted: '#8a948b'
-    textFaint: '#767f78'
+    textFaint: '#7a837c'
     # ── Accents ──
     accent: '#c8a44d'
     accentHi: '#dcb968'
@@ -84,7 +84,7 @@ palettes:
     # ── Text tiers ──
     text: '#f4ebe1'
     textMuted: '#a39588'
-    textFaint: '#847868'
+    textFaint: '#877b6b'
     # ── Accents ──
     accent: '#f4a261'
     accentHi: '#f7b67f'

--- a/js/main.js
+++ b/js/main.js
@@ -889,21 +889,30 @@ if (typeof document !== 'undefined') {
   }
 
   /* Three.js neural network — falls back to Canvas2D when WebGL is missing.
-     Dynamically imported so Three.js stays out of the main chunk, and deferred
-     to idle time so its ~130 KB download stays off the critical path — the
-     hero already has the noise gradient + name shader while it loads. */
+     Dynamically imported so Three.js stays out of the main chunk. Deferred
+     until the first user interaction (mousemove / scroll / touchstart) so the
+     ~130 KB chunk is off the critical path on page load; the noise gradient +
+     name shader fill the hero while it loads. On reduced-motion the canvas is
+     hidden entirely. */
   const canvas = document.getElementById('neural-canvas');
   if (canvas) {
     if (prefersReducedMotion()) {
       canvas.style.display = 'none';
     } else {
-      whenIdle(() => {
+      let started = false;
+      const startNeural = () => {
+        if (started) return;
+        started = true;
+        ['mousemove', 'scroll', 'touchstart'].forEach(evt =>
+          window.removeEventListener(evt, startNeural));
         import('./neural-net.js').then(({ NeuralNetwork, NeuralNetwork2D }) => {
           _disposables.push(
             hasWebGLSupport() ? new NeuralNetwork(canvas) : new NeuralNetwork2D(canvas),
           );
         });
-      });
+      };
+      ['mousemove', 'scroll', 'touchstart'].forEach(evt =>
+        window.addEventListener(evt, startNeural, { passive: true, once: true }));
     }
   }
 


### PR DESCRIPTION
## Summary

A full-pass review of the site touching CSS architecture, visual design, accessibility, and performance — no framework changes, no dependency additions.

### CSS modernization
- **Design token scales**: `--space-*`, `--tracking-*`, `--elev-*`, `--ease-spring` — consistent spacing, letter-spacing, elevation, and easing throughout
- **`@layer` cascade**: explicit `base, components` layers to end specificity wrestling
- **Native CSS nesting**: nav, timeline, contact-card, side-dot, cmd-item clusters converted
- **OKLCH colours**: theme CSS variables now ship as `oklch()` computed from palette hex; `generateCssBlock` derives them at generation time

### Palette & theme pipeline
- **Accent chroma taming**: `tameAccent()` in `generate-theme.js` desaturates the accent family by 14% OKLCH chroma so they read as refined rather than neon
- **Theme-sync regression test** (`test/theme-sync.test.js`): asserts `rewriteHtml(text, palette) === text` for every committed HTML page — catches palette drift before deploy, which is what silently broke `links.html`
- **Fix stale `links.html`**: regenerated from active palette

### Aesthetic refresh
- Reduced neon glow on buttons and cards (`--elev-*` shadows replace single-colour spreads)
- Removed hero background orbs (static noise gradient is cleaner)
- Removed `initMagneticButtons` (invisible effect, pure overhead on mobile)
- Spring easing (`cubic-bezier(0.34, 1.3, 0.64, 1)`) on interactive elements
- Card reveal: opacity/translateY crossfade replaces rotateY preserve-3d flip
- Tighter section type: larger `clamp()` headings + `max-width: 60ch` subtitles
- Project card background images dimmed to `opacity: 0.09` resting / `0.16` hover
- Research card icons replaced with a cohesive monoline SVG set (sparkle, eye, cube, layers, play-circle, network)

### Accessibility
- **`--text-faint` contrast**: `forest` 4.31:1 → 4.55:1, `apricot` 4.35:1 → 4.54:1 — both now meet WCAG AA 4.5:1 against their `bgAlt` backgrounds (`crimson` was already passing at 4.64:1)

### Performance
- **Defer neural-net Three.js chunk**: the `import('./neural-net.js')` (~130 KB gzipped) now fires on first user interaction (`mousemove` / `scroll` / `touchstart`) instead of `requestIdleCallback` — removes it from the critical path entirely on mobile while keeping the full Three.js quality once the user engages

### Other
- Projects sorted newest-to-oldest in `data/projects.js` and `projects.html` JSON-LD
- JSON-LD `name`/`headline` updated to include author suffix on all project pages

## Test plan
- [ ] `npm test` → 553/553 pass
- [ ] `npm run dev` → hero shows noise gradient immediately, neural net appears after first mouse move
- [ ] Hero canvas blank on cold load; animates after first interaction
- [ ] CV page skill bars render; `--text-faint` labels are legible
- [ ] Research cards reveal on click (opacity fade, not 3D flip)
- [ ] Project cards: faint background image, monoline icons visible
- [ ] `links.html` theme-color matches active palette
- [ ] `npm run generate-theme --dry-run` → no changes (idempotent)

https://claude.ai/code/session_01GaLm92qq8FzcHQHudVbXQn

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaLm92qq8FzcHQHudVbXQn)_