### PR TITLE
Fade the hero neural net in instead of popping it in

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -526,8 +526,17 @@ h3 {
   height: 100%;
   z-index: 1;
   /* above the noise gradient canvas */
-  will-change: transform;
+  will-change: transform, opacity;
   /* own compositor layer */
+  /* Hidden until the first frame paints, then faded in by the .is-visible
+     class (added from js/main.js) so the network doesn't pop in fully-formed
+     the moment the lazily-loaded Three.js chunk lands. */
+  opacity: 0;
+  transition: opacity 800ms ease;
+}
+
+#neural-canvas.is-visible {
+  opacity: 1;
 }
 
 /* Noise-gradient background canvas — sits behind the particle network */

--- a/js/main.js
+++ b/js/main.js
@@ -909,8 +909,15 @@ if (typeof document !== 'undefined') {
         ['mousemove', 'scroll', 'touchstart'].forEach(evt =>
           window.removeEventListener(evt, startNeural));
         import('./neural-net.js').then(({ NeuralNetwork, NeuralNetwork2D }) => {
+          /* Fade the canvas in once the first frame has painted (see the
+             #neural-canvas opacity transition in css/styles.css), so the
+             network materialises gently instead of popping in fully-formed
+             the instant the Three.js chunk lands. */
+          const reveal = () => canvas.classList.add('is-visible');
           _disposables.push(
-            hasWebGLSupport() ? new NeuralNetwork(canvas) : new NeuralNetwork2D(canvas),
+            hasWebGLSupport()
+              ? new NeuralNetwork(canvas, reveal)
+              : new NeuralNetwork2D(canvas, reveal),
           );
         });
       };

--- a/js/neural-net.js
+++ b/js/neural-net.js
@@ -42,10 +42,13 @@ export class NeuralNetwork {
   static ACCENT  = glvec(THEME.accent);
   static ACCENT2 = glvec(THEME.accent2);
 
-  constructor(canvas) {
+  constructor(canvas, onReady) {
     this.canvas = canvas;
     this.mouse = { x: 0, y: 0 };
     this.frameId = null;
+    /* Fired once, right after the first frame paints, so the hero can fade the
+       canvas in instead of letting the network pop in fully-formed. */
+    this._onReady = typeof onReady === 'function' ? onReady : null;
     this._isLowPower = isLowPowerDevice();
     this.particleCount = this._isLowPower ? 64 : NeuralNetwork.PARTICLE_COUNT;
     this.connectionDist = this._isLowPower ? 130 : NeuralNetwork.CONNECTION_DIST;
@@ -296,6 +299,15 @@ export class NeuralNetwork {
     this._lastDrawTime = now;
     this._update();
     this.renderer.render(this.scene, this.camera);
+    this._signalReady();
+  }
+
+  /* Invoke the onReady callback exactly once, after the first painted frame. */
+  _signalReady() {
+    if (!this._onReady) return;
+    const cb = this._onReady;
+    this._onReady = null;
+    cb();
   }
 
   _onResize() {
@@ -359,10 +371,12 @@ export class NeuralNetwork {
 
 /* CPU fallback for the hero background when WebGL is unavailable */
 export class NeuralNetwork2D {
-  constructor(canvas) {
+  constructor(canvas, onReady) {
     this.canvas = canvas;
     this._listeners = [];
     this._io = null;
+    /* Fired once, right after the first frame paints — see NeuralNetwork. */
+    this._onReady = typeof onReady === 'function' ? onReady : null;
     this.ctx = canvas.getContext('2d', { alpha: true });
     if (!this.ctx) return;
     this.mouse = { x: 0, y: 0 };
@@ -493,6 +507,15 @@ export class NeuralNetwork2D {
     if (this._lastDrawTime && (now - this._lastDrawTime) < this._minFrameTime) return;
     this._lastDrawTime = now;
     this._draw();
+    this._signalReady();
+  }
+
+  /* Invoke the onReady callback exactly once, after the first painted frame. */
+  _signalReady() {
+    if (!this._onReady) return;
+    const cb = this._onReady;
+    this._onReady = null;
+    cb();
   }
 
   destroy() {

--- a/test/main.node.test.mjs
+++ b/test/main.node.test.mjs
@@ -642,6 +642,64 @@ test('NeuralNetwork constructs and updates with mocked THREE', () => {
   }
 });
 
+test('NeuralNetwork fires onReady once after the first painted frame', () => {
+  const prevWindow = global.window;
+  const prevDocument = global.document;
+  const prevObserver = global.IntersectionObserver;
+  const prevRAF = global.requestAnimationFrame;
+  const prevCancel = global.cancelAnimationFrame;
+
+  __setThreeForTests(createMinimalThree());
+  global.window = {
+    innerWidth: 1200,
+    innerHeight: 800,
+    devicePixelRatio: 2,
+    addEventListener() {},
+  };
+  global.document = {
+    hidden: false,
+    addEventListener() {},
+    createElement(tag) {
+      if (tag !== 'canvas') return {};
+      return {
+        width: 0,
+        height: 0,
+        getContext() {
+          return {
+            createRadialGradient() { return { addColorStop() {} }; },
+            fillRect() {},
+            fillStyle: '',
+          };
+        },
+      };
+    },
+  };
+  global.IntersectionObserver = class {
+    constructor(cb) { this.cb = cb; }
+    observe() {}
+    disconnect() {}
+  };
+  global.requestAnimationFrame = () => 1;
+  global.cancelAnimationFrame = () => {};
+
+  try {
+    let readyCalls = 0;
+    const nn = new NeuralNetwork({}, () => { readyCalls += 1; });
+    assert.equal(readyCalls, 1, 'onReady must fire after the first frame paints');
+
+    /* Subsequent frames must not re-fire onReady (the hero only fades in once). */
+    nn._animate();
+    assert.equal(readyCalls, 1, 'onReady must fire exactly once');
+  } finally {
+    global.window = prevWindow;
+    global.document = prevDocument;
+    global.IntersectionObserver = prevObserver;
+    global.requestAnimationFrame = prevRAF;
+    global.cancelAnimationFrame = prevCancel;
+    __resetThreeForTests();
+  }
+});
+
 test('Globe3D constructs with mocked THREE and location data', () => {
   const prevWindow = global.window;
   const prevDocument = global.document;


### PR DESCRIPTION
The Three.js chunk is lazily imported on first interaction, so the
network previously snapped to full strength the instant it loaded.
Both NeuralNetwork and NeuralNetwork2D now accept an onReady callback
fired once after the first painted frame; main.js uses it to add an
.is-visible class, and #neural-canvas transitions from opacity 0 to 1
over 800ms. Reduced-motion users are unaffected (canvas stays hidden
and is never constructed).