### PR TITLE
Surface current work: real brand-stadium card + present-tense copy

### DIFF
--- a/data/projects.js
+++ b/data/projects.js
@@ -24,7 +24,7 @@ export const PROJECTS = [
             year: "2025",
             tags: ["AI","Computer Vision"],
             bg: "img/projects/annotated-stadium.webp",
-            description: "ABC.",
+            description: "A computer-vision system that measures how much screen time each brand gets in football broadcasts. A YOLO detector finds the perimeter boards and LED signage; a DenseNet201 classifier sorts each into one of 52 brands — coping with small, motion-blurred crops, a 40× class imbalance, and LED ads that rotate weekly. Runs in production on Azure, validated against human annotators.",
             url: "projects/brand-stadium.html",
         },
     {

--- a/index.html
+++ b/index.html
@@ -217,8 +217,9 @@
 
         <div class="about-text-col" data-animate data-delay="200">
           <p class="about-lead">
-            I'm a Senior AI Engineer at <strong>Mediapro</strong>, passionate about
-            building applications that bring cutting-edge research into production systems.
+            I'm a Senior AI Engineer at <strong>Mediapro</strong>, building generative-AI and
+            computer-vision systems for live sport and broadcast — bringing cutting-edge research
+            into production.
           </p>
           <p>
             My work spans <strong>generative AI</strong>, <strong>deep learning</strong>,
@@ -546,7 +547,7 @@
       <header class="section-header" data-animate>
         <span class="section-tag">Projects</span>
         <h2 class="section-title">Things I&rsquo;ve Built</h2>
-        <p class="section-subtitle">Here is a random selection of some of my past projects; refresh the page to see a different set. I will add more projects here once they are completed and I am allowed to talk about them.</p>
+        <p class="section-subtitle">A random selection of my work, from brand analytics in live sport to collaborative AR research. Refresh the page to shuffle the set.</p>
       </header>
       <!-- Items injected by JS — data source: PROJECTS in data/projects.js -->
       <div class="projects-grid" id="projects-grid"></div>

--- a/index.html
+++ b/index.html
@@ -547,7 +547,7 @@
       <header class="section-header" data-animate>
         <span class="section-tag">Projects</span>
         <h2 class="section-title">Things I&rsquo;ve Built</h2>
-        <p class="section-subtitle">A random selection of my work, from brand analytics in live sport to collaborative AR research. Refresh the page to shuffle the set.</p>
+        <p class="section-subtitle">A random selection of my work, from brand analytics and Gaussian-splat 3D reconstruction in live sport to collaborative AR research. Refresh the page to shuffle the set.</p>
       </header>
       <!-- Items injected by JS — data source: PROJECTS in data/projects.js -->
       <div class="projects-grid" id="projects-grid"></div>


### PR DESCRIPTION
## Summary

Follow-up to the site review's "the site documents your past better than your present" finding. Three small but high-impact copy fixes.

- **`data/projects.js`** — replace the `"ABC."` placeholder description on the 2025 brand-recognition project with a real summary. The placeholder was shipping live on both the homepage card and the `projects.html` grid, so the newest, most marketable project was rendering as a card reading "ABC."
- **`index.html` (projects subtitle)** — drop the apologetic, frozen-in-past framing ("…some of my **past** projects… once they are completed and **I am allowed to talk about them**") and replace with present-tense copy that names the range of work.
- **`index.html` (About lead)** — tighten to name the present work: generative-AI / computer-vision for live sport and broadcast.

The brand-stadium *detail page* was already in great shape — this just makes the card and surrounding copy match it.

## Test plan
- [x] `npm test` → 609/609 pass
- [x] Visual check: brand-stadium card renders the real description on `projects.html`; About lead reads cleanly
- [x] Refresh the homepage a few times — the brand card no longer shows "ABC." when picked

https://claude.ai/code/session_01GaLm92qq8FzcHQHudVbXQn

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaLm92qq8FzcHQHudVbXQn)_