### PR TITLE
Fix blank WebGL globe/hero after a theme switch

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -751,6 +751,30 @@ export function initLifecycleCleanup(disposables) {
   window.addEventListener('pagehide', cleanup);
 }
 
+/* Swap a WebGL <canvas> for a pristine clone before a theme-switch rebuild.
+
+   The colour-baked WebGL surfaces (noise-gradient hero, Three.js globe) force
+   their context to be lost in destroy() (renderer.forceContextLoss() /
+   WEBGL_lose_context.loseContext()) so teardown frees the GPU resources
+   promptly. But a force-lost context is permanent for that node — getContext()
+   keeps returning the same dead context, so rebuilding the instance on the
+   *same* canvas paints onto a context that never restores and the surface goes
+   blank (the bug behind "the globe disappears in light mode" and "the hero
+   effect is gone after a theme switch").
+
+   Replacing the node with cloneNode(false) gives the rebuild a fresh canvas
+   that can acquire a live context, while preserving the id / classes / inline
+   attributes so CSS and the FOUC fade-in still apply. Returns the live canvas
+   (the clone when a swap happened, else the original), so callers must use the
+   returned reference for the rebuild. No-op (returns the input) when the node
+   is missing or detached. */
+export function freshCanvasForRebuild(canvas) {
+  if (!canvas || !canvas.parentNode || typeof canvas.cloneNode !== 'function') return canvas;
+  const clone = canvas.cloneNode(false);
+  canvas.parentNode.replaceChild(clone, canvas);
+  return clone;
+}
+
 /* Test surface — ES module exports.
    UI behaviours (js/ui.js), DOM animations (js/animations.js), and the
    noise gradient (js/noise-gradient.js) are re-exported here so the test
@@ -860,8 +884,8 @@ if (typeof document !== 'undefined') {
      palette colours in at construction (the shader source / gradient stops).
      They are therefore built through small factory closures so a theme switch
      can tear the instance down and rebuild it with the now-active palette. */
-  const noiseCanvas  = document.getElementById('noise-canvas');
-  const neuralCanvas = document.getElementById('neural-canvas');
+  let noiseCanvas  = document.getElementById('noise-canvas');
+  let neuralCanvas = document.getElementById('neural-canvas');
   let noiseInstance  = null;
   let neuralInstance = null;
   let neuralStarted  = false;
@@ -920,11 +944,16 @@ if (typeof document !== 'undefined') {
     if (noiseInstance) {
       try { noiseInstance.destroy(); } catch (_) { /* ignore */ }
       noiseInstance = null;
+      /* destroy() force-lost the WebGL context — rebuild on a fresh canvas. */
+      noiseCanvas = freshCanvasForRebuild(noiseCanvas);
       buildNoise();
     }
     if (neuralStarted && neuralInstance) {
       try { neuralInstance.destroy(); } catch (_) { /* ignore */ }
       neuralInstance = null;
+      /* Canvas2D survives reuse, but swap for symmetry + a clean drawing
+         buffer so the rebuilt net starts from a blank frame. */
+      neuralCanvas = freshCanvasForRebuild(neuralCanvas);
       buildNeural();
     }
   };
@@ -955,7 +984,7 @@ if (typeof document !== 'undefined') {
   /* Three.js Globe — geocode any entries missing lat/lon, then build. Built
      through a closure so a theme switch can rebuild it with the active palette
      (globe.js resolves colours from getTheme() per instance). */
-  const globeCanvas = document.getElementById('globe-canvas');
+  let globeCanvas = document.getElementById('globe-canvas');
   let globeInstance = null;
   const buildGlobe = () => {
     /* Dynamically imported (Three.js) and only when the globe nears the
@@ -978,7 +1007,7 @@ if (typeof document !== 'undefined') {
   }
 
   /* 2D Europe Map — Canvas-based representation of European locations */
-  const europeCanvas = document.getElementById('europe-canvas');
+  let europeCanvas = document.getElementById('europe-canvas');
   let europeInstance = null;
   const buildEurope = () => {
     europeInstance = new EuropeMap2D(europeCanvas);
@@ -994,11 +1023,16 @@ if (typeof document !== 'undefined') {
     if (globeInstance) {
       try { globeInstance.destroy?.(); } catch (_) { /* ignore */ }
       globeInstance = null;
+      /* Globe3D.destroy() calls renderer.forceContextLoss(); the WebGL
+         context can't be revived on the same node, so rebuild on a clone. */
+      globeCanvas = freshCanvasForRebuild(globeCanvas);
       buildGlobe();
     }
     if (europeInstance) {
       try { europeInstance.destroy?.(); } catch (_) { /* ignore */ }
       europeInstance = null;
+      /* Canvas2D — swap for a clean buffer to match the globe rebuild path. */
+      europeCanvas = freshCanvasForRebuild(europeCanvas);
       buildEurope();
     }
   };

--- a/test/theme-rebuild.test.mjs
+++ b/test/theme-rebuild.test.mjs
@@ -1,0 +1,71 @@
+/* ───────────────────────────────────────────────────────────
+   Theme-switch rebuild — fresh-canvas regression tests.
+
+   When the user toggles light/dark, js/main.js destroys the
+   colour-baked WebGL surfaces (noise-gradient hero, Three.js globe)
+   and rebuilds them with the now-active palette. destroy() force-loses
+   the WebGL context (renderer.forceContextLoss() / WEBGL_lose_context),
+   which permanently kills that <canvas>'s context: reusing the same
+   node means getContext() returns the already-lost context and the
+   surface renders blank.
+
+   freshCanvasForRebuild() swaps the node for a pristine clone so the
+   rebuilt instance can acquire a live context. These tests pin that
+   behaviour and that the rebuild handlers actually use it.
+   ─────────────────────────────────────────────────────────── */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { freshCanvasForRebuild } from '../js/main.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+function fakeCanvas(id) {
+  const node = { id, parentNode: null };
+  node.cloneNode = () => fakeCanvas(node.id);
+  return node;
+}
+
+test('freshCanvasForRebuild swaps the canvas for a pristine clone', () => {
+  const original = fakeCanvas('globe-canvas');
+  let replaced = null;
+  const parent = {
+    replaceChild(newNode, oldNode) {
+      assert.equal(oldNode, original, 'must replace the original node');
+      replaced = newNode;
+      newNode.parentNode = parent;
+    },
+  };
+  original.parentNode = parent;
+
+  const fresh = freshCanvasForRebuild(original);
+
+  assert.notEqual(fresh, original,
+    'must return a brand-new canvas node — reusing the force-lost one renders blank');
+  assert.equal(fresh, replaced, 'returned node must be the one inserted into the DOM');
+  assert.equal(fresh.id, 'globe-canvas', 'clone must keep the id so CSS/styling still applies');
+});
+
+test('freshCanvasForRebuild is a safe no-op when the canvas is null or detached', () => {
+  assert.equal(freshCanvasForRebuild(null), null, 'null in → null out');
+  assert.equal(freshCanvasForRebuild(undefined), undefined, 'undefined in → undefined out');
+
+  const orphan = { id: 'x', parentNode: null, cloneNode() { return {}; } };
+  assert.equal(freshCanvasForRebuild(orphan), orphan,
+    'no parent node → return the original unchanged');
+});
+
+test('theme-change rebuilds obtain a fresh canvas before rebuilding the WebGL surfaces', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'js', 'main.js'), 'utf8');
+  /* The noise-gradient hero (home) and the Three.js globe (travel) are both
+     WebGL and both force-lose their context on destroy — each rebuild path
+     must swap in a fresh canvas first or it repaints onto a dead context. */
+  assert.ok(/freshCanvasForRebuild\(\s*noiseCanvas\s*\)/.test(src),
+    'noise-gradient rebuild must call freshCanvasForRebuild(noiseCanvas)');
+  assert.ok(/freshCanvasForRebuild\(\s*globeCanvas\s*\)/.test(src),
+    'globe rebuild must call freshCanvasForRebuild(globeCanvas)');
+});


### PR DESCRIPTION
The colour-baked WebGL surfaces (Three.js globe on travel.html, the
noise-gradient hero on the homepage) force their GL context to be lost in
destroy() so teardown frees GPU resources promptly. A theme switch then
rebuilt the instance on the *same* <canvas>, but a force-lost context is
permanent for that node — getContext() keeps returning the dead context, so
the rebuilt surface painted onto a context that never restores and went blank
(globe vanished in light mode; hero background died after toggling).

Add freshCanvasForRebuild(), which swaps the node for a pristine clone
(preserving id/classes/attributes) before each theme-switch rebuild so the new
instance can acquire a live context. The Canvas2D surfaces (neural net, Europe
map) are swapped too for a clean drawing buffer and symmetry.

Adds red/green coverage in test/theme-rebuild.test.mjs.