### PR TITLE
Fix Great Britain rendering filled on the Europe 2D map

### DIFF
--- a/js/europe-map.js
+++ b/js/europe-map.js
@@ -531,20 +531,12 @@ export class EuropeMap2D {
       lon >= nearMinLon && lon <= nearMaxLon &&
       lat >= nearMinLat && lat <= nearMaxLat;
 
-    /* Pass 1: fill only local rings (small islands that fill correctly) */
-    ctx.fillStyle = THEME.globe.land;
-    for (const ring of this._europeRings) {
-      if (!isLocal(ring)) continue;
-      ctx.beginPath();
-      ctx.moveTo(this._lonToX(ring[0][0]), this._latToY(ring[0][1]));
-      for (let i = 1; i < ring.length; i++) {
-        ctx.lineTo(this._lonToX(ring[i][0]), this._latToY(ring[i][1]));
-      }
-      ctx.closePath();
-      ctx.fill();
-    }
-
-    /* Pass 2: stroke coastlines.
+    /* Coastlines are stroke-only (neon outline). The mainland is a single
+       "global" ring whose interior seas (Mediterranean, Black Sea) are holes
+       the TopoJSON decoder drops, so flood-filling it would paint those seas as
+       land — hence the continent is never filled. Islands ("local" rings) must
+       follow the same rule or Great Britain etc. render as solid blobs while
+       every neighbouring country is a hollow outline.
        Local rings: draw all segments normally.
        Global rings: only draw segments near Europe (eliminates cross-map artifacts). */
     const strokes = [

--- a/test/europe-map.test.mjs
+++ b/test/europe-map.test.mjs
@@ -204,6 +204,35 @@ test('EuropeMap2D: drawTrips renders layered neon arcs', () => {
   });
 });
 
+test('EuropeMap2D: island landmasses are not filled (consistent with the mainland outline)', () => {
+  const { canvas, fills } = createCanvasAndContext();
+  const tooltip = createTooltip();
+
+  /* A small island ring (Great Britain — longitude span < 90°, so the renderer
+     classifies it "local") and the European mainland ring (span ≥ 90°, the
+     "global" continent). The mainland is only ever stroked; the island must be
+     rendered the same way, otherwise Great Britain shows up as a solid filled
+     blob while every neighbouring country is a hollow neon outline. */
+  const greatBritain = [
+    [-5, 50], [-3, 51], [-1, 53], [0, 55], [-2, 57], [-4, 58], [-5, 56], [-5, 50],
+  ];
+  const mainland = [
+    [-10, 36], [10, 40], [40, 45], [80, 60], [100, 65], [60, 70], [20, 60], [-10, 36],
+  ];
+
+  withGlobals(makeEnv({ pins: [] }, tooltip), () => {
+    const map = new EuropeMap2D(canvas);
+    map._europeRings = [greatBritain, mainland];
+
+    map._drawEuropeBorders();
+
+    assert.ok(!fills.includes(THEME.globe.land),
+      'no landmass should be flood-filled — islands must match the mainland outline');
+    assert.equal(fills.length, 0,
+      'drawing the Europe borders should stroke coastlines only, never fill land');
+  });
+});
+
 test('EuropeMap2D: drawTrips converts hex trip color to rgba glow layers', () => {
   const { canvas, strokes } = createCanvasAndContext();
   const tooltip = createTooltip();


### PR DESCRIPTION
## Problem

On the travel-page Europe 2D map, Great Britain rendered as a **solid filled blob** while every neighbouring country was a hollow neon outline.

## Cause

`_drawEuropeBorders()` in `js/europe-map.js` ran two passes:

- **Pass 1 — fill** every "local" ring (a landmass whose longitude span is `< 90°`, i.e. islands)
- **Pass 2 — stroke** all coastlines

The European mainland is a single "global" ring (span ≥ 90°) that is intentionally **never** filled: its interior seas (Mediterranean, Black Sea) are *holes* the TopoJSON decoder drops, so flood-filling the outer ring would paint those seas as land. That left the continent as a hollow outline — but Pass 1 still filled every island (Great Britain, Ireland, Iceland, Sicily…), so they stood out as solid shapes. Great Britain is the largest, hence the most obvious.

## Fix

Drop the island-only fill pass so **all** landmasses render consistently as stroke-only neon coastlines, matching the mainland. The `isLocal` classifier is still used in the stroke pass (islands draw all segments; the continent draws only near-Europe segments to avoid cross-map artifacts). The change is palette-agnostic, so it's correct in both light and dark themes.

## Tests

Added red/green coverage in `test/europe-map.test.mjs`: feeds an island ring + a mainland ring into `_drawEuropeBorders()` and asserts no land fill occurs.

- Before the fix: fails — the island is filled with `THEME.globe.land`.
- After the fix: passes.

Full suite: **702 passed / 0 failed** (1 skip is the browser-gated Playwright test).

https://claude.ai/code/session_01AassypfdLssvBhGiVD1mys

---
_Generated by [Claude Code](https://claude.ai/code/session_01AassypfdLssvBhGiVD1mys)_