### PR TITLE
a11y: support prefers-contrast: more

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -192,6 +192,30 @@
 }
 /* @theme-generated-light-end */
 
+/* ─── Higher contrast on request ──────────────────────────────
+   Honour an explicit `prefers-contrast: more` user setting. The base
+   palette already clears WCAG AA for body and muted text, so this only
+   firms up the elements that sit closest to the line: hairline borders /
+   separators become clearly visible, the faintest helper text steps up to
+   the (AA-passing) muted tone, and inline accent links gain an underline so
+   they no longer rely on colour alone (WCAG 1.4.1). Everything derives from
+   existing palette tokens, so it tracks any active palette and both themes.
+   (Selector list: the `[data-theme="light"]` arm wins the cascade on the
+   light root; bare `:root` covers the dark default.) */
+@media (prefers-contrast: more) {
+  :root,
+  :root[data-theme="light"] {
+    --border: rgb(var(--text-rgb) / 0.32);
+    --border-hov: rgb(var(--accent-rgb) / 0.7);
+    --text-faint: var(--text-muted);
+  }
+
+  .inline-link {
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
+  }
+}
+
 /* ─── Cross-document view transitions ─────────────────────────
    Opt the whole multi-page site into the View Transitions API so same-origin
    navigations (home ↔ projects ↔ project detail ↔ cv ↔ travel ↔ links) animate


### PR DESCRIPTION
## What

Adds a high-contrast override gated on `@media (prefers-contrast: more)` — the one genuine accessibility gap from the site review (previously zero `prefers-contrast` support).

## Why this scope

I measured the actual WCAG contrast across both themes before touching anything:

- **Muted text already passes AA comfortably** — ~6.4:1 (dark), ~6.1:1 (light), near AAA. My earlier worry was unfounded; no change needed.
- The override therefore targets only the elements nearest the line.

## Changes

- **Borders/separators**: hairline alpha steps from `0.08` → `0.32` so they're clearly visible; `--border-hov` firms up to `0.7`.
- **Faintest helper text**: `--text-faint` steps up to the AA-passing muted tone.
- **Inline accent links**: gain an underline so they no longer rely on colour alone (WCAG 1.4.1).

All values derive from existing palette tokens, so the block tracks any active palette and both light/dark themes — no hardcoded colours, nothing in the generated regions.

## Deliberately *not* in this PR (needs a design decision)

While measuring, I found the primary button (`--on-accent` text on `--accent`) is **3.67:1 in the default theme** — and accent-as-small-text on alt surfaces is **4.39:1** (just under AA). The root cause is that `--accent` does double duty as both foreground text and button background, so a token-level boost can't fix one without regressing the other (remapping to `--accent-hi` would drop the button to 2.68:1). Fixing this properly means a small token refactor (a dedicated accent-text token) — a brand/design call, so I left it out rather than silently change colours.

## Verification

- `npm test` — 703/703 pass
- `npm run build` — clean

https://claude.ai/code/session_019ZuPSHULXvyacgxfC7oW6U

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZuPSHULXvyacgxfC7oW6U)_