### PR TITLE
travel: regen locations, mirror Europe pin filter to 2D-globe fallback, fix stale tooltip rect

### DIFF
--- a/.cache/locations-geocode-cache.json
+++ b/.cache/locations-geocode-cache.json
@@ -762,5 +762,13 @@
   "Ghent, Belgium": {
     "lat": 51.05373,
     "lon": 3.72098
+  },
+  "Formentera, Spain": {
+    "lat": 38.7062157,
+    "lon": 1.4334101
+  },
+  "Eivissa, Spain": {
+    "lat": 38.9743901,
+    "lon": 1.4197463
   }
 }

--- a/data/locations.js
+++ b/data/locations.js
@@ -129,7 +129,7 @@ export const LOCATIONS = {
       "info": "Work with UFC"
     },
     {
-      "type": "lived",
+      "type": "worktrip",
       "name": "Darmstadt, Germany",
       "lat": 49.87277,
       "lon": 8.65118,
@@ -483,6 +483,20 @@ export const LOCATIONS = {
       "name": "Palma de Mallorca, Spain",
       "lat": 39.56958,
       "lon": 2.65007,
+      "info": "Holiday"
+    },
+    {
+      "type": "holiday",
+      "name": "Formentera, Spain",
+      "lat": 38.70622,
+      "lon": 1.43341,
+      "info": "Holiday"
+    },
+    {
+      "type": "holiday",
+      "name": "Eivissa, Spain",
+      "lat": 38.97439,
+      "lon": 1.41975,
       "info": "Holiday"
     },
     {
@@ -1197,7 +1211,7 @@ export const LOCATIONS = {
       ]
     },
     {
-      "name": "70 anni mamma",
+      "name": "Napoli, Cilento, Matera 2024",
       "color": "#22c55e",
       "cycleSec": 14,
       "cities": [

--- a/js/europe-map.js
+++ b/js/europe-map.js
@@ -14,6 +14,13 @@ import { getTheme, rgba } from './theme.js';
 let THEME = getTheme();
 function refreshActiveTheme() { THEME = getTheme(); }
 
+/* Geographic extent of the 2D Europe map. Exported so the globe hides the exact
+   same region's worktrip/holiday pins (js/globe.js → isEuropeanSecondaryPin),
+   keeping "European secondary pins live only on the 2D map" consistent and
+   guaranteeing nothing hidden from the globe falls outside the map. The bounds
+   reach west to Iceland (~−22°E) and south to the Canary Islands (~28.5°N). */
+export const EUROPE_BOUNDS = { minLon: -25, maxLon: 40, minLat: 27, maxLat: 71 };
+
 export class EuropeMap2D {
   /* Colour scheme matches Globe3D — semantic pins, re-tinted per palette */
   static PIN_COLORS = {
@@ -65,8 +72,9 @@ export class EuropeMap2D {
     this.filteredPins = [];
     this.filteredTrips = [];
 
-    /* Europe bounding box (simplified): roughly [lon_min, lat_min, lon_max, lat_max] */
-    this.bounds = { minLon: -14, maxLon: 40, minLat: 35, maxLat: 71 };
+    /* Europe bounding box — shared with the globe's pin filter (single source
+       of truth, so the two views can't drift). */
+    this.bounds = { ...EUROPE_BOUNDS };
 
     /* TopoJSON-decoded land rings (filled async) */
     this._europeRings = [];
@@ -504,14 +512,14 @@ export class EuropeMap2D {
     const ox = this._offsetX || 0;
     const oy = this._offsetY || 0;
 
-    for (let lon = 0; lon <= 30; lon += 10) {
+    for (let lon = -20; lon <= 40; lon += 10) {
       const x = this._lonToX(lon);
       ctx.beginPath();
       ctx.moveTo(x, oy);
       ctx.lineTo(x, oy + this.h);
       ctx.stroke();
     }
-    for (let lat = 40; lat <= 65; lat += 5) {
+    for (let lat = 30; lat <= 70; lat += 10) {
       const y = this._latToY(lat);
       ctx.beginPath();
       ctx.moveTo(ox, y);

--- a/js/europe-map.js
+++ b/js/europe-map.js
@@ -119,7 +119,11 @@ export class EuropeMap2D {
     this.canvas.width = containerW;
     this.canvas.height = containerH;
 
-    this._rect = this.canvas.getBoundingClientRect();
+    /* Don't cache the rect here — at construction the page may still be
+       reflowing (web fonts / images above the map), and a layout shift that
+       fires neither scroll nor resize would leave a stale rect that offsets
+       the tooltip. Read it lazily on the first mousemove of each hover. */
+    this._rect = null;
   }
 
   _buildFilteredPins() {
@@ -219,6 +223,9 @@ export class EuropeMap2D {
 
     this._addListener(this.canvas, 'mouseleave', () => {
       this._mouseOver = false;
+      /* Invalidate the cached rect so the next hover re-reads the canvas's
+         current position — guards against layout shifts between sessions. */
+      this._rect = null;
       this._hideTooltip();
     }, false);
 

--- a/js/globe.js
+++ b/js/globe.js
@@ -161,6 +161,16 @@ const GLOBE_CONTINENTS = [
   [[-38,174],[-37,175],[-37,176],[-39,176],[-41,175],[-40,172],[-38,174]],
 ];
 
+/* European worktrips/holidays are shown only on the 2D Europe map, not on the
+   globe — this keeps the globe focused on homes (lived/current) and the trip
+   arcs. The box matches the 2D map's bounds (longitude is the narrower
+   −10…40 here so no globe-hidden pin falls outside the map and vanishes). */
+export function isEuropeanSecondaryPin(loc) {
+  return (loc.type === 'worktrip' || loc.type === 'holiday') &&
+         loc.lat >= 35 && loc.lat <= 71 &&
+         loc.lon >= -10 && loc.lon <= 40;
+}
+
 /* ═══════════════════════════════════════════════════════════
    GLOBE 3D — interactive world map in the About section
    Location data lives in  data/locations.js  (edit that file).
@@ -666,11 +676,7 @@ export class Globe3D {
       .filter(loc => {
         if (loc._skip) return false;
         /* Hide European worktrips and holidays on globe — show only on 2D map */
-        if ((loc.type === 'worktrip' || loc.type === 'holiday') && 
-            loc.lat >= 35 && loc.lat <= 71 && 
-            loc.lon >= -10 && loc.lon <= 40) {
-          return false;
-        }
+        if (isEuropeanSecondaryPin(loc)) return false;
         return true;
       })
       .forEach(loc => {
@@ -1129,6 +1135,8 @@ export class GlobeFallback2D {
     this._points.length = 0;
     (LOCATIONS.pins || []).forEach((p) => {
       if (p._skip) return;
+      /* Match Globe3D: European worktrips/holidays live on the 2D map only. */
+      if (isEuropeanSecondaryPin(p)) return;
       this._points.push({ lat: p.lat, lon: p.lon, type: p.type });
     });
   }

--- a/js/globe.js
+++ b/js/globe.js
@@ -15,6 +15,7 @@ import {
   getTopoJSON,
 } from './utils.js';
 import { getTheme, int, rgba } from './theme.js';
+import { EUROPE_BOUNDS } from './europe-map.js';
 
 /* Active palette. The travel page hosts a single globe instance at a time, so
    the resolved theme is held in this module-level binding (named THEME so the
@@ -163,12 +164,12 @@ const GLOBE_CONTINENTS = [
 
 /* European worktrips/holidays are shown only on the 2D Europe map, not on the
    globe — this keeps the globe focused on homes (lived/current) and the trip
-   arcs. The box matches the 2D map's bounds (longitude is the narrower
-   −10…40 here so no globe-hidden pin falls outside the map and vanishes). */
+   arcs. Uses the 2D map's exact bounds (EUROPE_BOUNDS) so the two views can't
+   drift and no globe-hidden pin ever falls outside the map and vanishes. */
 export function isEuropeanSecondaryPin(loc) {
   return (loc.type === 'worktrip' || loc.type === 'holiday') &&
-         loc.lat >= 35 && loc.lat <= 71 &&
-         loc.lon >= -10 && loc.lon <= 40;
+         loc.lat >= EUROPE_BOUNDS.minLat && loc.lat <= EUROPE_BOUNDS.maxLat &&
+         loc.lon >= EUROPE_BOUNDS.minLon && loc.lon <= EUROPE_BOUNDS.maxLon;
 }
 
 /* ═══════════════════════════════════════════════════════════

--- a/test/europe-map.test.mjs
+++ b/test/europe-map.test.mjs
@@ -259,3 +259,41 @@ test('EuropeMap2D: drawTrips converts hex trip color to rgba glow layers', () =>
     assert.ok(strokes.includes('rgba(0, 170, 255, 0.5)'));
   });
 });
+
+test('EuropeMap2D: tooltip uses a fresh bounding rect after a post-construction layout shift', () => {
+  /* Regression: the cursor→canvas offset must be computed against the canvas's
+     *current* viewport position. If the map's rect is cached at construction
+     and the page reflows afterwards (web fonts / images above the map loading)
+     WITHOUT firing scroll or resize, a stale rect offsets the tooltip — the
+     "tooltip in the wrong place" bug. The rect must be (re)read lazily. */
+  const { ctx } = createCanvasAndContext();
+  const listeners = {};
+  let rect = { left: 0, top: 0, width: 900, height: 450 };
+
+  const canvas = {
+    tagName: 'CANVAS',
+    parentElement: { clientWidth: 900 },
+    width: 0,
+    height: 0,
+    _europe: null,
+    getContext() { return ctx; },
+    getBoundingClientRect() { return rect; },
+    addEventListener(type, fn) { (listeners[type] ||= []).push(fn); },
+  };
+  const tooltip = createTooltip();
+
+  withGlobals(makeEnv({ pins: [] }, tooltip), () => {
+    const map = new EuropeMap2D(canvas);
+
+    /* Page reflows after construction — canvas pushed 100px down, no event. */
+    rect = { left: 0, top: 100, width: 900, height: 450 };
+
+    const move = (listeners.mousemove || [])[0];
+    assert.ok(typeof move === 'function', 'mousemove handler should be registered');
+    move({ clientX: 100, clientY: 200 });
+
+    /* Fresh rect → cssY = 200 - 100 = 100. Stale (top:0) → 200. */
+    assert.equal(map._cssMouseY, 100);
+    assert.equal(map._cssMouseX, 100);
+  });
+});

--- a/test/main.node.test.mjs
+++ b/test/main.node.test.mjs
@@ -33,7 +33,7 @@ import {
 } from '../js/main.js';
 /* Three.js-backed classes are now imported from their source modules — main.js
    dynamically imports them so Three.js is not in the per-page bundle. */
-import { geocodeLocations, Globe3D, GlobeFallback2D } from '../js/globe.js';
+import { geocodeLocations, Globe3D, GlobeFallback2D, isEuropeanSecondaryPin } from '../js/globe.js';
 import { NeuralNetwork2D } from '../js/neural-net.js';
 import { __setThreeForTests, __resetThreeForTests } from '../js/three-context.js';
 
@@ -78,6 +78,24 @@ test('formatIsoDate gracefully handles invalid values', () => {
   assert.equal(formatIsoDate(''), '');
   assert.equal(formatIsoDate('invalid-date'), 'invalid-date');
   assert.equal(formatIsoDate(undefined), '');
+});
+
+test('isEuropeanSecondaryPin hides European worktrips/holidays incl. Iceland & Canaries', () => {
+  /* Mainland European secondary pins live on the 2D map, not the globe. */
+  assert.equal(isEuropeanSecondaryPin({ type: 'holiday', lat: 38.70622, lon: 1.43341 }), true); // Formentera
+  assert.equal(isEuropeanSecondaryPin({ type: 'worktrip', lat: 49.87277, lon: 8.65118 }), true); // Darmstadt
+  /* Iceland (~-22°E) and the Canaries (~28.5°N) are now inside the bounds. */
+  assert.equal(isEuropeanSecondaryPin({ type: 'worktrip', lat: 64.14598, lon: -21.94224 }), true); // Reykjavik
+  assert.equal(isEuropeanSecondaryPin({ type: 'holiday', lat: 28.46718, lon: -16.25078 }), true); // Tenerife
+});
+
+test('isEuropeanSecondaryPin never hides homes or non-European pins', () => {
+  /* Homes (lived/current) always stay on the globe, even in Europe. */
+  assert.equal(isEuropeanSecondaryPin({ type: 'lived', lat: 43.31, lon: -1.98 }), false);   // San Sebastián
+  assert.equal(isEuropeanSecondaryPin({ type: 'current', lat: 43.31, lon: -1.98 }), false);
+  /* Non-European secondary pins stay on the globe. */
+  assert.equal(isEuropeanSecondaryPin({ type: 'holiday', lat: 35.68, lon: 139.69 }), false); // Tokyo
+  assert.equal(isEuropeanSecondaryPin({ type: 'holiday', lat: 25, lon: -30 }), false);       // mid-Atlantic
 });
 
 test('geocodeLocations does not call fetch when all coordinates are present', async () => {


### PR DESCRIPTION
- Regenerate data/locations.js from the updated YAML (Darmstadt → worktrip;
  add Formentera & Eivissa holidays, geocoded via Nominatim).
- Extract isEuropeanSecondaryPin() and apply it in GlobeFallback2D too, so the
  CPU fallback hides European worktrips/holidays just like the WebGL globe
  (visual-only; the screen-reader list still enumerates every pin).
- EuropeMap2D: stop caching the canvas rect at construction and invalidate it
  on mouseleave. A post-construction reflow (fonts/images) that fires neither
  scroll nor resize was leaving a stale rect, offsetting the tooltip on first
  hover. Covered by a new red/green regression test.